### PR TITLE
Preload Z-Wave JS device db

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,5 @@
+Prior to opening a PR request, it is encouraged to update the included Z-Wave device database by running the following command:
+
+```python
+python3 -m script.gen_zjs_device_config_db
+```

--- a/demo.py
+++ b/demo.py
@@ -5,6 +5,7 @@ import os
 import pubnub
 
 from vivintpy.account import Account
+from vivintpy.devices import VivintDevice
 from vivintpy.devices.camera import MOTION_DETECTED, Camera
 
 pubnub.set_stream_logger(name="pubnub", level=logging.ERROR)
@@ -14,8 +15,8 @@ async def main():
     logging.getLogger().setLevel(logging.DEBUG)
     logging.debug("Demo started")
 
-    def camera_motion_callback(**kwargs):
-        logging.debug("Motion detected from camera: %s", kwargs)
+    def camera_motion_callback(device: VivintDevice) -> None:
+        logging.debug("Motion detected from camera: %s", device)
 
     account = Account(username=os.environ["username"], password=os.environ["password"])
 
@@ -32,7 +33,8 @@ async def main():
                 logging.debug(f"\t\t\tDevice: {device}")
                 if isinstance(device, Camera):
                     device.on(
-                        MOTION_DETECTED, lambda event: camera_motion_callback(**event)
+                        MOTION_DETECTED,
+                        lambda event: camera_motion_callback(event["device"]),
                     )
 
     try:

--- a/script/gen_zjs_device_config_db.py
+++ b/script/gen_zjs_device_config_db.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""Generate an updated zjs_device_config_db.json."""
+import asyncio
+import logging
+import sys
+
+from vivintpy.zjs_device_config_db import (
+    _device_config_db_file_exists,
+    download_zjs_device_config_db,
+)
+
+logging.getLogger("vivintpy.zjs_device_config_db").setLevel(logging.DEBUG)
+logging.getLogger().setLevel(logging.DEBUG)
+
+
+async def main():
+    """Run the script."""
+    logging.debug("Running script")
+
+    await download_zjs_device_config_db()
+
+    if not _device_config_db_file_exists():
+        logging.error("Unable to generate zjs_device_config_db.json")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,4 @@
 """vivintpy setup script."""
-import os
-
 import setuptools
-
-file_name = "vivintpy/zjs_device_config_db.json"
-
-with open(file_name, "w") as file:
-    pass
 
 setuptools.setup()

--- a/vivintpy/devices/__init__.py
+++ b/vivintpy/devices/__init__.py
@@ -12,6 +12,8 @@ from ..zjs_device_config_db import get_zwave_device_info
 if TYPE_CHECKING:
     from .alarm_panel import AlarmPanel
 
+DEVICE = "device"
+
 
 def get_device_class(device_type: str) -> Callable:
     """Maps a device_type string to the class that implements that device."""
@@ -157,15 +159,11 @@ class VivintDevice(Entity):
         return [self._manufacturer, self._model]
 
     def emit(self, event_name: str, data: dict) -> None:
-        """Add identifying device data and then send to parent."""
-        super().emit(
-            event_name,
-            {
-                "name": self.name,
-                "panel_id": self.panel_id,
-                **data,
-            },
-        )
+        """Add device data and then send to parent."""
+        if data.get(DEVICE) is None:
+            data.update({DEVICE: self})
+
+        super().emit(event_name, data)
 
 
 class UnknownDevice(VivintDevice):

--- a/vivintpy/devices/alarm_panel.py
+++ b/vivintpy/devices/alarm_panel.py
@@ -14,7 +14,7 @@ from ..enums import ArmedState, DeviceType
 from ..exceptions import VivintSkyApiError
 from ..utils import add_async_job, first_or_none
 from ..vivintskyapi import VivintSkyApi
-from . import UnknownDevice, VivintDevice, get_device_class
+from . import VivintDevice, get_device_class
 
 if TYPE_CHECKING:
     from ..system import System

--- a/vivintpy/devices/camera.py
+++ b/vivintpy/devices/camera.py
@@ -128,16 +128,21 @@ class Camera(VivintDevice):
         """Handles a pubnub message addressed to this camera."""
         super().handle_pubnub_message(message)
 
+        event = None
+
         if message.get(Attribute.CAMERA_THUMBNAIL_DATE):
-            self.emit(THUMBNAIL_READY, message)
+            event = THUMBNAIL_READY
         elif message.get(Attribute.DING_DONG):
-            self.emit(DOORBELL_DING, message)
+            event = DOORBELL_DING
         elif message.keys() == set([Attribute.ID, Attribute.TYPE]):
-            self.emit(VIDEO_READY, message)
+            event = VIDEO_READY
         elif message.get(Attribute.VISITOR_DETECTED) or message.keys() in [
             set([Attribute.ID, Attribute.ACTUAL_TYPE, Attribute.STATE]),
             set([Attribute.ID, Attribute.DETER_ON_DUTY, Attribute.TYPE]),
         ]:
-            self.emit(MOTION_DETECTED, message)
+            event = MOTION_DETECTED
+
+        if event is not None:
+            self.emit(event, {"message": message})
 
         _LOGGER.debug("Message received by %s: %s", self.name, message)

--- a/vivintpy/zjs_device_config_db.json
+++ b/vivintpy/zjs_device_config_db.json
@@ -1,0 +1,12733 @@
+{
+  "0x0000:0x0000:0x0000": {
+    "description": "9 endpoints",
+    "label": "PowerStrip",
+    "manufacturer": "Sigma Designs (Former Zensys)"
+  },
+  "0x0000:0x0000:0x0003": {
+    "description": "endpoints for dimming and on/off",
+    "label": "ZM5202",
+    "manufacturer": "Sigma Designs (Former Zensys)"
+  },
+  "0x0000:0x0001:0x0001": {
+    "description": "QuickStick Combo",
+    "label": "HUSBZB-1",
+    "manufacturer": "Sigma Designs (Former Zensys)"
+  },
+  "0x0000:0x0001:0x0409": {
+    "description": "Yale Real Living Touchscreen Lever Lock",
+    "label": "YRL220",
+    "manufacturer": "Sigma Designs (Former Zensys)"
+  },
+  "0x0000:0x0003:0x0001": {
+    "description": "Window/Door Sensor",
+    "label": "SM-A702A",
+    "manufacturer": "Sigma Designs (Former Zensys)"
+  },
+  "0x0000:0x0003:0x0002": {
+    "description": "Z-Wave power plug",
+    "label": "SM-PZ701U",
+    "manufacturer": "Sigma Designs (Former Zensys)"
+  },
+  "0x0000:0x0003:0x0003": {
+    "description": "Z-Wave Battery Wall Controller",
+    "label": "K8",
+    "manufacturer": "Sigma Designs (Former Zensys)"
+  },
+  "0x0000:0x0003:0x0008": {
+    "description": "Smart Temperature & Humidity Sensor",
+    "label": "M417_9E",
+    "manufacturer": "Sigma Designs (Former Zensys)"
+  },
+  "0x0000:0x0003:0x000b": {
+    "description": "Z-wave 9 channel_module",
+    "label": "PS9EP",
+    "manufacturer": "Sigma Designs (Former Zensys)"
+  },
+  "0x0000:0x0003:0xa305": {
+    "description": "Z-Wave Battery Wall Controller",
+    "label": "K8",
+    "manufacturer": "Sigma Designs (Former Zensys)"
+  },
+  "0x0000:0x0004:0x0004": {
+    "description": "700 Series-based Controller",
+    "label": "ZST10-700",
+    "manufacturer": "Silicon Labs"
+  },
+  "0x0001:0x4243:0x0000": {
+    "description": "Anyplace Switch",
+    "label": "Aspire RF9575",
+    "manufacturer": "Eaton"
+  },
+  "0x0001:0x444d:0x3330": {
+    "description": "Wall Dimmer",
+    "label": "ZDM230",
+    "manufacturer": "HomePro"
+  },
+  "0x0001:0x444d:0x3332": {
+    "description": "2-Wire Dimmer 1-Gang",
+    "label": "ZDW232",
+    "manufacturer": "HomePro"
+  },
+  "0x0001:0x4450:0x3030": {
+    "description": "Scene Capable Dimmer Module",
+    "label": "ZDP100",
+    "manufacturer": "HomePro"
+  },
+  "0x0001:0x4457:0x3033": {
+    "description": "Wall Mounted 3-Way Dimmer Receiver",
+    "label": "ZDW103",
+    "manufacturer": "HomePro"
+  },
+  "0x0001:0x4457:0x3034": {
+    "description": "Wall Mounted Dimmer",
+    "label": "ZDW104",
+    "manufacturer": "HomePro"
+  },
+  "0x0001:0x4457:0x3230": {
+    "description": "Two Wire Wall Dimmer",
+    "label": "HomePro",
+    "manufacturer": "ACT - Advanced Control Technologies"
+  },
+  "0x0001:0x4952:0x3030": {
+    "description": "PIR Motion Sensor",
+    "label": "ZIR000 / ZIR010",
+    "manufacturer": "HomePro"
+  },
+  "0x0001:0x4952:0x3130": {
+    "description": "PIR Motion Sensor",
+    "label": "ZIR000 / ZIR010",
+    "manufacturer": "HomePro"
+  },
+  "0x0001:0x4952:0x3330": {
+    "description": "PIR Motion Sensor",
+    "label": "ZIR000 / ZIR010",
+    "manufacturer": "HomePro"
+  },
+  "0x0001:0x5246:0x3133": {
+    "description": "Isolated Contact Fixture Module",
+    "label": "ZRF113",
+    "manufacturer": "HomePro"
+  },
+  "0x0001:0x524d:0x3330": {
+    "description": "Wall Switch/Transmitter (2-gang)",
+    "label": "ZRM230",
+    "manufacturer": "HomePro"
+  },
+  "0x0001:0x5250:0x3030": {
+    "description": "Z-Wave Plug-In Appliance Module",
+    "label": "ZRP100",
+    "manufacturer": "HomePro"
+  },
+  "0x0001:0x5252:0x3530": {
+    "description": "Relay Receptacle",
+    "label": "ZRR150",
+    "manufacturer": "HomePro"
+  },
+  "0x0001:0x5257:0x3033": {
+    "description": "20-Amp 3-Way Relay",
+    "label": "ZRW103",
+    "manufacturer": "HomePro"
+  },
+  "0x0001:0x5257:0x3133": {
+    "description": "Relay Switch",
+    "label": "ZRW113",
+    "manufacturer": "HomePro"
+  },
+  "0x0001:0x5257:0x3330": {
+    "description": "Wall Mounted 3-Way Switch",
+    "label": "ZRW230",
+    "manufacturer": "HomePro"
+  },
+  "0x0001:0x544d:0x3330": {
+    "description": "Dual Paddle Wall Mounted Transmitter",
+    "label": "ZTM230",
+    "manufacturer": "HomePro"
+  },
+  "0x0001:0x7fff:0x7fff": {
+    "description": "Applicance Module",
+    "label": "ZRP200",
+    "manufacturer": "HomePro"
+  },
+  "0x0002:0x0002:0x4005": {
+    "description": "",
+    "label": "014G0205",
+    "manufacturer": "Danfoss"
+  },
+  "0x0002:0x0002:0x400a": {
+    "description": "HC-Z Hydronic Floor Heating Controller",
+    "label": "014G0210",
+    "manufacturer": "Danfoss"
+  },
+  "0x0002:0x0003:0x8010": {
+    "description": "Room Thermostat",
+    "label": "MT2649 / DRS21",
+    "manufacturer": "Danfoss"
+  },
+  "0x0002:0x0005:0x0003": {
+    "description": "Living Connect Z Thermostat 2.51",
+    "label": "LCZ251",
+    "manufacturer": "Danfoss"
+  },
+  "0x0002:0x0005:0x0004": {
+    "description": "Living Connect Z Thermostat",
+    "label": "LC-13",
+    "manufacturer": "Danfoss"
+  },
+  "0x0002:0x0005:0x0017": {
+    "description": "EBV Connect Setpoint Thermostat",
+    "label": "014G0800",
+    "manufacturer": "Danfoss"
+  },
+  "0x0002:0x0005:0x0175": {
+    "description": "Devolo Thermostat (09356)",
+    "label": "MT02650",
+    "manufacturer": "Danfoss"
+  },
+  "0x0002:0x0115:0xa010": {
+    "description": "Popp Wireless Thermostatic Valve TRV",
+    "label": "010101",
+    "manufacturer": "Danfoss"
+  },
+  "0x0002:0x0248:0xa010": {
+    "description": "Living Connect Z Thermostat",
+    "label": "DTHERMZ6",
+    "manufacturer": "Danfoss"
+  },
+  "0x0002:0x0248:0xa020": {
+    "description": "Z-Wave room sensor",
+    "label": "DTHERMZ5",
+    "manufacturer": "Danfoss"
+  },
+  "0x0002:0x0248:0xa030": {
+    "description": "HC-10",
+    "label": "DFBH10Z1 / 088N7110",
+    "manufacturer": "Danfoss"
+  },
+  "0x0002:0x0248:0xa040": {
+    "description": "HC-5",
+    "label": "DFBH5Z01 / 088N7105",
+    "manufacturer": "Danfoss"
+  },
+  "0x0002:0x0804:0x2000": {
+    "description": "Danfoss RXZ1",
+    "label": "087N743100",
+    "manufacturer": "Danfoss"
+  },
+  "0x0002:0x0804:0x2002": {
+    "description": "Danfoss RXZ2C",
+    "label": "087N777200",
+    "manufacturer": "Danfoss"
+  },
+  "0x0002:0x6fff:0xa010": {
+    "description": "Electronic radiator thermostat, intended for use with water based room radiators.",
+    "label": "Keemple smart radiator",
+    "manufacturer": "Danfoss"
+  },
+  "0x0002:0x7fff:0xa010": {
+    "description": "Genius Valve",
+    "label": "014G0804",
+    "manufacturer": "Danfoss"
+  },
+  "0x0002:0x8004:0x0001": {
+    "description": "Danfoss RET BZ",
+    "label": "087N774500",
+    "manufacturer": "Danfoss"
+  },
+  "0x0002:0x8004:0x0400": {
+    "description": "RF Relay switching unit",
+    "label": "RXZ",
+    "manufacturer": "Danfoss"
+  },
+  "0x0002:0x8004:0x2010": {
+    "description": "Danfoss Randall - (Single Channel RF Relay Switching Unit)",
+    "label": "RZ1",
+    "manufacturer": "Danfoss"
+  },
+  "0x0002:0x8004:0x2020": {
+    "description": "Single Channel RF Relay Switching Unit",
+    "label": "RZ1-HP",
+    "manufacturer": "Danfoss"
+  },
+  "0x0002:0x8005:0x0001": {
+    "description": "Living Connect Z Thermostat",
+    "label": "LC-13",
+    "manufacturer": "Danfoss"
+  },
+  "0x0002:0x8005:0x0002": {
+    "description": "Living Connect Z Thermostat",
+    "label": "LC-13",
+    "manufacturer": "Danfoss"
+  },
+  "0x0002:0x8005:0x2001": {
+    "description": "Danfoss Link\u2122 Boiler Relay",
+    "label": "014G0272",
+    "manufacturer": "Danfoss"
+  },
+  "0x0002:0x8007:0x0200": {
+    "description": "Air CCM",
+    "label": "HRVCCM",
+    "manufacturer": "Danfoss"
+  },
+  "0x0002:0x8007:0x0202": {
+    "description": "Air CCM",
+    "label": "HRVCCM",
+    "manufacturer": "Danfoss"
+  },
+  "0x0003:0x6341:0x0544": {
+    "description": "Schlage Lock",
+    "label": "BE469",
+    "manufacturer": "Schlage"
+  },
+  "0x0003:0x6341:0x5044": {
+    "description": "Schlage Lock",
+    "label": "BE469",
+    "manufacturer": "Schlage"
+  },
+  "0x0003:0x6349:0x5044": {
+    "description": "Schlage Lock",
+    "label": "BE468",
+    "manufacturer": "Schlage"
+  },
+  "0x0005:0x0001:0x0003": {
+    "description": "In-Wall Dual Receptacle",
+    "label": "HA-01C",
+    "manufacturer": "Intermatic"
+  },
+  "0x0005:0x0002:0x0003": {
+    "description": "Appliance Module",
+    "label": "HA02",
+    "manufacturer": "Intermatic"
+  },
+  "0x0005:0x0003:0x0003": {
+    "description": "Lamp Module",
+    "label": "HA03",
+    "manufacturer": "Intermatic"
+  },
+  "0x0005:0x0004:0x0003": {
+    "description": "Outdoor Module",
+    "label": "HA04",
+    "manufacturer": "Intermatic"
+  },
+  "0x0005:0x0005:0x0003": {
+    "description": "Screw in lamp module",
+    "label": "HA05",
+    "manufacturer": "Intermatic"
+  },
+  "0x0005:0x4341:0x0600": {
+    "description": "Dimmer Switch",
+    "label": "CA600",
+    "manufacturer": "Intermatic"
+  },
+  "0x0005:0x4341:0x3000": {
+    "description": "Wall Switch",
+    "label": "CA3000",
+    "manufacturer": "Intermatic"
+  },
+  "0x0005:0x4341:0x3500": {
+    "description": "15 Amp Split-Duplex Receptacle",
+    "label": "CA3500",
+    "manufacturer": "Intermatic"
+  },
+  "0x0005:0x4341:0x3750": {
+    "description": "Contactor/Switch",
+    "label": "CA3750",
+    "manufacturer": "Intermatic"
+  },
+  "0x0005:0x4341:0x8900": {
+    "description": "Z-Wave Thermostat",
+    "label": "CA8900",
+    "manufacturer": "Intermatic"
+  },
+  "0x0005:0x4841:0x0014": {
+    "description": "Dimmer Switch",
+    "label": "HA14WD",
+    "manufacturer": "Intermatic"
+  },
+  "0x0005:0x4841:0x0018": {
+    "description": "15-amp Wall Switch",
+    "label": "HA18",
+    "manufacturer": "Intermatic"
+  },
+  "0x0005:0x4841:0x0020": {
+    "description": "Dimmer Switch",
+    "label": "HA20",
+    "manufacturer": "Intermatic"
+  },
+  "0x0005:0x5045:0x0653": {
+    "description": "Pool Control",
+    "label": "PE653",
+    "manufacturer": "Intermatic"
+  },
+  "0x0005:0x5045:0x0953": {
+    "description": "Intermatic MultiWave Five Channel Wireless Remote Controller",
+    "label": "PE953",
+    "manufacturer": "Intermatic"
+  },
+  "0x0008:0x0007:0x0020": {
+    "description": "Thermostat",
+    "label": "WDTC-20",
+    "manufacturer": "Wayne Dalton"
+  },
+  "0x0008:0x5452:0x5442": {
+    "description": "RCS Thermostat",
+    "label": "XL524",
+    "manufacturer": "Wayne Dalton"
+  },
+  "0x000c:0x0001:0x0003": {
+    "description": "HomeSeer HomeTroller-SEL",
+    "label": "HT-SEL",
+    "manufacturer": "HomeSeer Technologies"
+  },
+  "0x000c:0x0003:0x0002": {
+    "description": "Valve Controller",
+    "label": "HS-WV100+",
+    "manufacturer": "HomeSeer Technologies"
+  },
+  "0x000c:0x0004:0x0001": {
+    "description": "Z-Wave Multi Sensorr",
+    "label": "HS-HSM200",
+    "manufacturer": "HomeSeer Technologies"
+  },
+  "0x000c:0x0201:0x0008": {
+    "description": "Z-Wave Door/Window Sensor",
+    "label": "HS-DS100+",
+    "manufacturer": "HomeSeer Technologies"
+  },
+  "0x000c:0x0201:0x0009": {
+    "description": "Z-Wave Plus Motion Sensor",
+    "label": "HS-MS100+",
+    "manufacturer": "HomeSeer Technologies"
+  },
+  "0x000c:0x0201:0x000a": {
+    "description": "Z-Wave Plus Leak Sensor",
+    "label": "HS-LS100+",
+    "manufacturer": "HomeSeer Technologies"
+  },
+  "0x000c:0x0201:0x000b": {
+    "description": "Floodlight Sensor",
+    "label": "HS-FLS100+",
+    "manufacturer": "HomeSeer Technologies"
+  },
+  "0x000c:0x0201:0x000c": {
+    "description": "Floodlight Sensor",
+    "label": "HS-FLS100-G2",
+    "manufacturer": "HomeSeer Technologies"
+  },
+  "0x000c:0x0202:0x0001": {
+    "description": "Z-Wave Indicator Light Sensor",
+    "label": "HS-FS100-L",
+    "manufacturer": "HomeSeer Technologies"
+  },
+  "0x000c:0x0203:0x0001": {
+    "description": "Scene Capable Fan Control Switch",
+    "label": "HS-FC200+",
+    "manufacturer": "HomeSeer Technologies"
+  },
+  "0x000c:0x4447:0x3031": {
+    "description": "Appliance Module",
+    "label": "HS-PA100+",
+    "manufacturer": "HomeSeer Technologies"
+  },
+  "0x000c:0x4447:0x3033": {
+    "description": "Scene Capable Wall Switch",
+    "label": "HS-WS100+",
+    "manufacturer": "HomeSeer Technologies"
+  },
+  "0x000c:0x4447:0x3034": {
+    "description": "Scene Capable Wall Dimmer Switch",
+    "label": "WD-100",
+    "manufacturer": "HomeSeer Technologies"
+  },
+  "0x000c:0x4447:0x3035": {
+    "description": "Scene Capable Wall Switch",
+    "label": "HS-WS200+",
+    "manufacturer": "HomeSeer Technologies"
+  },
+  "0x000c:0x4447:0x3036": {
+    "description": "Scene Capable Wall Dimmer Switch",
+    "label": "HS-WD200+",
+    "manufacturer": "HomeSeer Technologies"
+  },
+  "0x000c:0x4744:0x3032": {
+    "description": "Scene Capable Wall Dimmer Switch",
+    "label": "WD-100",
+    "manufacturer": "HomeSeer Technologies"
+  },
+  "0x0010:0x0001:0x0001": {
+    "description": "ThereGate Static Controller",
+    "label": "800Z",
+    "manufacturer": "Residential Control Systems, Inc. (RCS)"
+  },
+  "0x0010:0x0001:0x0002": {
+    "description": "Thermostat",
+    "label": "TZ43",
+    "manufacturer": "Residential Control Systems, Inc. (RCS)"
+  },
+  "0x0010:0x0001:0x0009": {
+    "description": "Thermostat",
+    "label": "TZ45",
+    "manufacturer": "Residential Control Systems, Inc. (RCS)"
+  },
+  "0x0010:0x0001:0x000b": {
+    "description": "Thermostat",
+    "label": "TZ45",
+    "manufacturer": "Residential Control Systems, Inc. (RCS)"
+  },
+  "0x0010:0x0001:0x1001": {
+    "description": "FIBARO -2 Gateway",
+    "label": "HC",
+    "manufacturer": "Residential Control Systems, Inc. (RCS)"
+  },
+  "0x0010:0x0504:0x3431": {
+    "description": "RCS C Load Controller",
+    "label": "PMC40-L",
+    "manufacturer": "Residential Control Systems, Inc. (RCS)"
+  },
+  "0x0010:0x454d:0x3532": {
+    "description": "Z-Wave Energy Meter",
+    "label": "EM52",
+    "manufacturer": "Residential Control Systems, Inc. (RCS)"
+  },
+  "0x0010:0x5053:0x3231": {
+    "description": "RCS Pool Controller",
+    "label": "PSCH21",
+    "manufacturer": "Residential Control Systems, Inc. (RCS)"
+  },
+  "0x0010:0x5442:0x5432": {
+    "description": "Thermostat",
+    "label": "TBZ48",
+    "manufacturer": "Residential Control Systems, Inc. (RCS)"
+  },
+  "0x0012:0x0001:0x0001": {
+    "description": "Sanjose USB Dongle",
+    "label": "ZW-66",
+    "manufacturer": "Tell It Online"
+  },
+  "0x0014:0x0100:0x0000": {
+    "description": "BFT B-EBA",
+    "label": "P111535",
+    "manufacturer": "Cyberhouse"
+  },
+  "0x0014:0x2001:0x0102": {
+    "description": "Linear Door/Window Sensor",
+    "label": "WADWAZ",
+    "manufacturer": "Cyberhouse"
+  },
+  "0x0014:0x2002:0x0203": {
+    "description": "Linear PIR Sensor",
+    "label": "WAPIRZ",
+    "manufacturer": "Cyberhouse"
+  },
+  "0x0014:0x2009:0x0903": {
+    "description": "Linear -1 Siren",
+    "label": "WA105DBZ",
+    "manufacturer": "Cyberhouse"
+  },
+  "0x0014:0x4450:0x3030": {
+    "description": "Linear -2",
+    "label": "PD300Z",
+    "manufacturer": "Cyberhouse"
+  },
+  "0x0014:0x4457:0x3034": {
+    "description": "Linear -1",
+    "label": "WD500Z",
+    "manufacturer": "Cyberhouse"
+  },
+  "0x0014:0x4742:0x3030": {
+    "description": "Linear -1",
+    "label": "GB00Z",
+    "manufacturer": "Cyberhouse"
+  },
+  "0x0014:0x4744:0x3032": {
+    "description": "Linear -2",
+    "label": "GD00Z",
+    "manufacturer": "Cyberhouse"
+  },
+  "0x0014:0x5246:0x3133": {
+    "description": "Linear -1",
+    "label": "FS20Z",
+    "manufacturer": "Cyberhouse"
+  },
+  "0x0014:0x5250:0x3030": {
+    "description": "Linear -2",
+    "label": "PS15Z",
+    "manufacturer": "Cyberhouse"
+  },
+  "0x0014:0x5257:0x3033": {
+    "description": "Linear -1",
+    "label": "WS15Z",
+    "manufacturer": "Cyberhouse"
+  },
+  "0x0014:0x5442:0x5431": {
+    "description": "Linear Thermostat",
+    "label": "TBZ48",
+    "manufacturer": "Cyberhouse"
+  },
+  "0x0014:0x5457:0x3033": {
+    "description": "Linear -1",
+    "label": "WT00Z",
+    "manufacturer": "Cyberhouse"
+  },
+  "0x0015:0x0001:0x0001": {
+    "description": "Mini Energy Dimmer",
+    "label": "MH-P210",
+    "manufacturer": "Lexel"
+  },
+  "0x0015:0x0002:0x0001": {
+    "description": "Mini Energy switch",
+    "label": "MH-S210",
+    "manufacturer": "Lexel"
+  },
+  "0x0015:0x1007:0x0002": {
+    "description": "Curtain Motor",
+    "label": "JTB-1007-02",
+    "manufacturer": "Lexel"
+  },
+  "0x0015:0x3102:0x0204": {
+    "description": "MCO Home -EU",
+    "label": "MH-S314",
+    "manufacturer": "Lexel"
+  },
+  "0x0015:0x5102:0x0103": {
+    "description": "MCO Home -US",
+    "label": "MH-S513",
+    "manufacturer": "Lexel"
+  },
+  "0x0015:0x8015:0x0001": {
+    "description": "Door Lock",
+    "label": "LS-8015-ZW",
+    "manufacturer": "Lexel"
+  },
+  "0x0016:0x0001:0x0001": {
+    "description": "EchoStar USB Link",
+    "label": "203126",
+    "manufacturer": "PowerLynx"
+  },
+  "0x0017:0x0001:0x0002": {
+    "description": "EbV HeatApp Sensor",
+    "label": "9600050000",
+    "manufacturer": "HiTech Automation"
+  },
+  "0x0017:0x0001:0x0111": {
+    "description": "Telguard",
+    "label": "GDC1",
+    "manufacturer": "HiTech Automation"
+  },
+  "0x0017:0x0006:0x0003": {
+    "description": "EbV floor heating regulator",
+    "label": "9600801000",
+    "manufacturer": "HiTech Automation"
+  },
+  "0x0018:0x0001:0x0001": {
+    "description": "LGUplus Gateway Dongle",
+    "label": "GWG-01",
+    "manufacturer": "Balboa Instruments"
+  },
+  "0x0019:0x0001:0x0001": {
+    "description": "Leviton ThinkEssentials Software",
+    "label": "CTTEP",
+    "manufacturer": "ControlThink LC"
+  },
+  "0x001a:0x0000:0x0001": {
+    "description": "Eaton\u2019s Home Automation Hub",
+    "label": "HOMECT",
+    "manufacturer": "Eaton"
+  },
+  "0x001a:0x0042:0x0053": {
+    "description": "Motion Sensor",
+    "label": "RF96PIRBMS",
+    "manufacturer": "Eaton"
+  },
+  "0x001a:0x0053:0x0050": {
+    "description": "Plug-In Module - ON/OFF",
+    "label": "RF96APM",
+    "manufacturer": "Eaton"
+  },
+  "0x001a:0x4243:0x0000": {
+    "description": "Anyplace Switch",
+    "label": "RF9575",
+    "manufacturer": "Eaton"
+  },
+  "0x001a:0x4441:0x0000": {
+    "description": "Dimmer Accessory Switch",
+    "label": "RF9542-Z",
+    "manufacturer": "Eaton"
+  },
+  "0x001a:0x4441:0x0502": {
+    "description": "Z-Wave Plus smart accessory dimmer",
+    "label": "RF9642",
+    "manufacturer": "Eaton"
+  },
+  "0x001a:0x4441:0xaa00": {
+    "description": "Dimmer Accessory Switch",
+    "label": "RF9542-Z",
+    "manufacturer": "Eaton"
+  },
+  "0x001a:0x4449:0x0000": {
+    "description": "600W / 1000W Dimmer Light Switch",
+    "label": "RF9534-N / RF9536-N / RF9540-N",
+    "manufacturer": "Eaton"
+  },
+  "0x001a:0x4449:0x0001": {
+    "description": "1000W Dimmer Light Switch",
+    "label": "RF9537-N",
+    "manufacturer": "Eaton"
+  },
+  "0x001a:0x4449:0x0002": {
+    "description": "Smart Dimmer",
+    "label": "RF9534",
+    "manufacturer": "Eaton"
+  },
+  "0x001a:0x4449:0x0003": {
+    "description": "ASPIRE RF Plug-In Z-Wave Lamp Dimmer",
+    "label": "RFLDM",
+    "manufacturer": "Eaton"
+  },
+  "0x001a:0x4449:0x0101": {
+    "description": "All Load Dimmer Light Switch",
+    "label": "RF9540-N",
+    "manufacturer": "Eaton"
+  },
+  "0x001a:0x4449:0x0501": {
+    "description": "Z-Wave Plus universal smart dimmer",
+    "label": "RF9640",
+    "manufacturer": "Eaton"
+  },
+  "0x001a:0x4449:0xaa00": {
+    "description": "All Load Dimmer Light Switch",
+    "label": "RF9540-N",
+    "manufacturer": "Eaton"
+  },
+  "0x001a:0x4449:0xff00": {
+    "description": "All Load Dimmer Light Switch",
+    "label": "RF9540-N",
+    "manufacturer": "Eaton"
+  },
+  "0x001a:0x5244:0x0000": {
+    "description": "Duplex receptacle",
+    "label": "RFTR9505-T / RFTR9605",
+    "manufacturer": "Eaton"
+  },
+  "0x001a:0x5244:0x0505": {
+    "description": "Eatons Z-Wave Plus Wireless Receptacle",
+    "label": "RFTR9605-T",
+    "manufacturer": "Eaton"
+  },
+  "0x001a:0x5342:0x0000": {
+    "description": "Battery Switch",
+    "label": "RF9500",
+    "manufacturer": "Eaton"
+  },
+  "0x001a:0x534c:0x0000": {
+    "description": "15A Light Switch",
+    "label": "RF9501",
+    "manufacturer": "Eaton"
+  },
+  "0x001a:0x534c:0x0503": {
+    "description": "Z-Wave Plus wireless switch",
+    "label": "RF9601",
+    "manufacturer": "Eaton"
+  },
+  "0x001a:0x5352:0x0000": {
+    "description": "Accessory Switch",
+    "label": "RF9517",
+    "manufacturer": "Eaton"
+  },
+  "0x001a:0x5352:0x0504": {
+    "description": "Z-Wave Plus smart accessory switch",
+    "label": "RF9617",
+    "manufacturer": "Eaton"
+  },
+  "0x001a:0x5354:0x0000": {
+    "description": "Single-Pole Wireless Light Switch",
+    "label": "RF9518",
+    "manufacturer": "Eaton"
+  },
+  "0x001a:0x5354:0x0003": {
+    "description": "ASPIRE RF Appliance Control Plug-in Module",
+    "label": "RFAPM",
+    "manufacturer": "Eaton"
+  },
+  "0x001a:0x574d:0x0000": {
+    "description": "5-Scene Keypad",
+    "label": "RFWC5",
+    "manufacturer": "Eaton"
+  },
+  "0x001d:0x0001:0x0001": {
+    "description": "Touchpad Electronic Deadbolt",
+    "label": "914TRL",
+    "manufacturer": "Leviton"
+  },
+  "0x001d:0x0001:0x0304": {
+    "description": "Scene Capable Push On/Off",
+    "label": "DZMX1",
+    "manufacturer": "Leviton"
+  },
+  "0x001d:0x0001:0x0334": {
+    "description": "Scene Capable Receptacle",
+    "label": "DZR15",
+    "manufacturer": "Leviton"
+  },
+  "0x001d:0x001d:0x0000": {
+    "description": "Vizia RF + 2-Button Scene Controller with Switches",
+    "label": "VRCS2",
+    "manufacturer": "Leviton"
+  },
+  "0x001d:0x001d:0x030b": {
+    "description": "Serial Interface Module RS232",
+    "label": "VRC0P-1LW",
+    "manufacturer": "Leviton"
+  },
+  "0x001d:0x001d:0x1102": {
+    "description": "Vizia RF + 2-Button Scene Controller with Switches",
+    "label": "VRCS2",
+    "manufacturer": "Leviton"
+  },
+  "0x001d:0x0037:0x0002": {
+    "description": "Receptacle",
+    "label": "ZW15R",
+    "manufacturer": "Leviton"
+  },
+  "0x001d:0x0038:0x0002": {
+    "description": "4 Speed Fan Controller",
+    "label": "ZW4SF",
+    "manufacturer": "Leviton"
+  },
+  "0x001d:0x0101:0x0334": {
+    "description": "Scene Capable Plug-In Appliance Module, 300W",
+    "label": "VRP15",
+    "manufacturer": "Leviton"
+  },
+  "0x001d:0x0201:0x0206": {
+    "description": "Scene Capable Plug-In Lamp Dimming Module",
+    "label": "RZP03",
+    "manufacturer": "Leviton"
+  },
+  "0x001d:0x0202:0x0304": {
+    "description": "300W Scene Capable Plug-In Lamp Dimming Module",
+    "label": "VRP03",
+    "manufacturer": "Leviton"
+  },
+  "0x001d:0x0202:0x030b": {
+    "description": "300W Scene Capable Plug-In Lamp Dimming Module",
+    "label": "VRP03",
+    "manufacturer": "Leviton"
+  },
+  "0x001d:0x0301:0x0209": {
+    "description": "Scene Capable Push On/Off",
+    "label": "VRS15",
+    "manufacturer": "Leviton"
+  },
+  "0x001d:0x0301:0x0334": {
+    "description": "Scene Capable Push On/Off",
+    "label": "VRS15",
+    "manufacturer": "Leviton"
+  },
+  "0x001d:0x0401:0x0206": {
+    "description": "Dimmer switch 600w incandescent",
+    "label": "RZI06-1L",
+    "manufacturer": "Leviton"
+  },
+  "0x001d:0x0401:0x0209": {
+    "description": "Incandescent Scene Capable Dimmer",
+    "label": "VRI06",
+    "manufacturer": "Leviton"
+  },
+  "0x001d:0x0401:0x0334": {
+    "description": "Incandescent Scene Capable Dimmer",
+    "label": "VRI06",
+    "manufacturer": "Leviton"
+  },
+  "0x001d:0x0501:0x0209": {
+    "description": "Scene Capable Push On/Off Dimmer",
+    "label": "VRI10",
+    "manufacturer": "Leviton"
+  },
+  "0x001d:0x0501:0x0334": {
+    "description": "Scene Capable Push On/Off Dimmer",
+    "label": "VRI10",
+    "manufacturer": "Leviton"
+  },
+  "0x001d:0x0602:0x0334": {
+    "description": "Scene Capable Push On/Off Dimmer",
+    "label": "VRMX1",
+    "manufacturer": "Leviton"
+  },
+  "0x001d:0x0701:0x0206": {
+    "description": "4 zone controller",
+    "label": "VRCZ4",
+    "manufacturer": "Leviton"
+  },
+  "0x001d:0x0702:0x0261": {
+    "description": "4 zone controller",
+    "label": "VRCZ4",
+    "manufacturer": "Leviton"
+  },
+  "0x001d:0x0801:0x0206": {
+    "description": "4 zone controller",
+    "label": "VRCZ4",
+    "manufacturer": "Leviton"
+  },
+  "0x001d:0x0802:0x0209": {
+    "description": "4-Scene Controller",
+    "label": "VRCS4",
+    "manufacturer": "Leviton"
+  },
+  "0x001d:0x0802:0x0261": {
+    "description": "4-Scene Controller",
+    "label": "VRCS4",
+    "manufacturer": "Leviton"
+  },
+  "0x001d:0x0902:0x0215": {
+    "description": "1-Scene Controller",
+    "label": "VRCS1",
+    "manufacturer": "Leviton"
+  },
+  "0x001d:0x0b01:0x0209": {
+    "description": "RS-232 Serial Interface",
+    "label": "VRC0P (v1)",
+    "manufacturer": "Leviton"
+  },
+  "0x001d:0x0b02:0x032a": {
+    "description": "",
+    "label": "VRC0P",
+    "manufacturer": "Leviton"
+  },
+  "0x001d:0x0e01:0x0209": {
+    "description": "Electronic Low Voltage Scene Capable Dimmer",
+    "label": "VRE06",
+    "manufacturer": "Leviton"
+  },
+  "0x001d:0x0e01:0x0334": {
+    "description": "Electronic Low Voltage Scene Capable Dimmer",
+    "label": "VRE06",
+    "manufacturer": "Leviton"
+  },
+  "0x001d:0x0f01:0x0209": {
+    "description": "Scene Capable Switch",
+    "label": "VRS05",
+    "manufacturer": "Leviton"
+  },
+  "0x001d:0x0f01:0x0334": {
+    "description": "Scene Capable Switch",
+    "label": "VRS05",
+    "manufacturer": "Leviton"
+  },
+  "0x001d:0x1001:0x0209": {
+    "description": "Scene Capable Quiet Fan Speed Control",
+    "label": "VRF01",
+    "manufacturer": "Leviton"
+  },
+  "0x001d:0x1001:0x0334": {
+    "description": "Scene Capable Quiet Fan Speed Control",
+    "label": "VRF01",
+    "manufacturer": "Leviton"
+  },
+  "0x001d:0x1102:0x0243": {
+    "description": "Vizia RF + 2-Button Scene Controller with Switches",
+    "label": "VRCS2",
+    "manufacturer": "Leviton"
+  },
+  "0x001d:0x1202:0x0243": {
+    "description": "4-Zone Controller with local load control",
+    "label": "VRCZ4-MR",
+    "manufacturer": "Leviton"
+  },
+  "0x001d:0x1302:0x0243": {
+    "description": "4-Scene controller with load control",
+    "label": "VRCS4-M0",
+    "manufacturer": "Leviton"
+  },
+  "0x001d:0x1602:0x0209": {
+    "description": "Receptacle",
+    "label": "VRR15",
+    "manufacturer": "Leviton"
+  },
+  "0x001d:0x1603:0x0334": {
+    "description": "Receptacle",
+    "label": "VRR15",
+    "manufacturer": "Leviton"
+  },
+  "0x001d:0x1705:0x0334": {
+    "description": "Scene Capable Plug-in Dimmer",
+    "label": "VRPD3",
+    "manufacturer": "Leviton"
+  },
+  "0x001d:0x1706:0x0334": {
+    "description": "Scene Capable Plug-in Dimmer",
+    "label": "VRPD3",
+    "manufacturer": "Leviton"
+  },
+  "0x001d:0x1805:0x0334": {
+    "description": "Vizia RF + Scene Capable Plug-in Module",
+    "label": "VRPA1",
+    "manufacturer": "Leviton"
+  },
+  "0x001d:0x1902:0x0334": {
+    "description": "Lamp Module",
+    "label": "DZPD3",
+    "manufacturer": "Leviton"
+  },
+  "0x001d:0x1a02:0x0334": {
+    "description": "Plug-in Appliance Module",
+    "label": "DZPA1",
+    "manufacturer": "Leviton"
+  },
+  "0x001d:0x1b03:0x0334": {
+    "description": "Scene Capable Push On/Off",
+    "label": "DZMX1",
+    "manufacturer": "Leviton"
+  },
+  "0x001d:0x1c02:0x0334": {
+    "description": "Scene Capable Push On/Off",
+    "label": "DZS15",
+    "manufacturer": "Leviton"
+  },
+  "0x001d:0x1d04:0x0334": {
+    "description": "Scene Capable Receptacle",
+    "label": "DZR15",
+    "manufacturer": "Leviton"
+  },
+  "0x001d:0x2201:0x0209": {
+    "description": "Leviton VRR15",
+    "label": "VRR15_0806",
+    "manufacturer": "Leviton"
+  },
+  "0x001d:0x3201:0x0001": {
+    "description": "600W Dimmer",
+    "label": "DZ6HD",
+    "manufacturer": "Leviton"
+  },
+  "0x001d:0x3301:0x0001": {
+    "description": "1000W Dimmer",
+    "label": "DZ1KD",
+    "manufacturer": "Leviton"
+  },
+  "0x001d:0x3401:0x0001": {
+    "description": "Scene Capable Push On/Off",
+    "label": "DZ15S",
+    "manufacturer": "Leviton"
+  },
+  "0x001d:0x3501:0x0001": {
+    "description": "Lamp Module",
+    "label": "DZPD3",
+    "manufacturer": "Leviton"
+  },
+  "0x001d:0x3601:0x0001": {
+    "description": "Plug-in Appliance Module",
+    "label": "DZPA1",
+    "manufacturer": "Leviton"
+  },
+  "0x001d:0x5893:0x0820": {
+    "description": "Scene Capable Plug-in Dimmer",
+    "label": "VRPD3",
+    "manufacturer": "Leviton"
+  },
+  "0x001e:0x0002:0x0001": {
+    "description": "Wireless 3-in-1 Sensor",
+    "label": "EZMotion Express",
+    "manufacturer": "Express Controls"
+  },
+  "0x001e:0x0002:0x0002": {
+    "description": "Wireless 3-in-1 Sensor",
+    "label": "EZMotion Express",
+    "manufacturer": "Express Controls"
+  },
+  "0x001e:0x0004:0x0001": {
+    "description": "Multi Sensor",
+    "label": "EZMultiPli",
+    "manufacturer": "Express Controls"
+  },
+  "0x001e:0x0005:0x0002": {
+    "description": "EZZee",
+    "label": "EZZEE",
+    "manufacturer": "Express Controls"
+  },
+  "0x001f:0x4450:0x3030": {
+    "description": "HomePro ZDP200 Wall Dimmer",
+    "label": "ZDP200",
+    "manufacturer": "Scientia Technologies, Inc."
+  },
+  "0x0020:0x8007:0x1391": {
+    "description": "Advanced Remote Wireless Lighting Control",
+    "label": "45601",
+    "manufacturer": "Universal Electronics Inc."
+  },
+  "0x0020:0x8007:0x1398": {
+    "description": "Monster Revolution 200 remote",
+    "label": "8700BJ0-R",
+    "manufacturer": "Universal Electronics Inc."
+  },
+  "0x0021:0x0101:0x0101": {
+    "description": "Aoya Switch",
+    "label": "SWITCH",
+    "manufacturer": "Zykronix"
+  },
+  "0x002c:0x0002:0x0007": {
+    "description": "FlexNET Dongle",
+    "label": "Z-FLEXNET DONGL",
+    "manufacturer": "Flex Automation"
+  },
+  "0x0030:0x0001:0x0001": {
+    "description": "Cytech UCM/ZWave",
+    "label": "UCM/ZWAV",
+    "manufacturer": "Cytech Technology Pre Ltd."
+  },
+  "0x0033:0x4647:0x0001": {
+    "description": "US 115V",
+    "label": "FG IMS",
+    "manufacturer": "Electronic Solutions"
+  },
+  "0x0033:0x5250:0x3031": {
+    "description": "AC Motor Controller - Window Coverings",
+    "label": "ABMHZ",
+    "manufacturer": "Electronic Solutions"
+  },
+  "0x0033:0x5250:0x3032": {
+    "description": "DC Motor Controller - Window coverings",
+    "label": "DBMZ",
+    "manufacturer": "Electronic Solutions"
+  },
+  "0x0033:0x545a:0x0001": {
+    "description": "EU - Handheld remote control",
+    "label": "TZ 3300",
+    "manufacturer": "Electronic Solutions"
+  },
+  "0x0039:0x0001:0x0001": {
+    "description": "Tuxedo Touch Keypad and Z-Wave Controller",
+    "label": "TUXEDO TOUCH",
+    "manufacturer": "Honeywell"
+  },
+  "0x0039:0x0001:0x0003": {
+    "description": "Honeywell Lynx Touch",
+    "label": "L5100",
+    "manufacturer": "Honeywell"
+  },
+  "0x0039:0x0001:0x0005": {
+    "description": "Honeywell Vista Automation Module",
+    "label": "VAM",
+    "manufacturer": "Honeywell"
+  },
+  "0x0039:0x0001:0x0006": {
+    "description": "Honeywell Lyric Touch Panel",
+    "label": "LCP500-L",
+    "manufacturer": "Honeywell"
+  },
+  "0x0039:0x0001:0x0008": {
+    "description": "Lyric Gateway",
+    "label": "LCP300-L",
+    "manufacturer": "Honeywell"
+  },
+  "0x0039:0x0011:0x0001": {
+    "description": "Touchscreen Programmable Thermostat",
+    "label": "TH8320ZW",
+    "manufacturer": "Honeywell"
+  },
+  "0x0039:0x0011:0x0002": {
+    "description": "Honeywell - Opower",
+    "label": "TH8320ZW1026",
+    "manufacturer": "Honeywell"
+  },
+  "0x0039:0x0011:0x0003": {
+    "description": "Touchscreen Programmable Thermostat",
+    "label": "TH8320ZW",
+    "manufacturer": "Honeywell"
+  },
+  "0x0039:0x0011:0x0008": {
+    "description": "T6 Pro Z-Wave Programmable Thermostat",
+    "label": "TH6320ZW",
+    "manufacturer": "Honeywell"
+  },
+  "0x0039:0x1001:0x0007": {
+    "description": "Lynx Touch",
+    "label": "L7000-ME",
+    "manufacturer": "Honeywell"
+  },
+  "0x0039:0x4944:0x3038": {
+    "description": "In-Wall Smart Dimmer",
+    "label": "39351 / ZW3005",
+    "manufacturer": "Honeywell"
+  },
+  "0x0039:0x4944:0x3130": {
+    "description": "Z-Wave in-wall Smart Dimmer",
+    "label": "39357 / ZW3004",
+    "manufacturer": "Honeywell"
+  },
+  "0x0039:0x4944:0x3131": {
+    "description": "Z-Wave In-Wall Smart Fan Control",
+    "label": "39358 / ZW4002",
+    "manufacturer": "Honeywell"
+  },
+  "0x0039:0x4944:0x3235": {
+    "description": "In-Wall Smart Dimmer",
+    "label": "39351 / ZW3010",
+    "manufacturer": "Honeywell"
+  },
+  "0x0039:0x4944:0x3237": {
+    "description": "In-Wall Smart Toggle Dimmer",
+    "label": "39357 / ZW3011",
+    "manufacturer": "Honeywell"
+  },
+  "0x0039:0x4952:0x3036": {
+    "description": "In Wall Paddle",
+    "label": "39455 / ZW4005",
+    "manufacturer": "Honeywell"
+  },
+  "0x0039:0x4952:0x3037": {
+    "description": "In-Wall Smart Toggle Switch",
+    "label": "39354",
+    "manufacturer": "Honeywell"
+  },
+  "0x0039:0x4952:0x3133": {
+    "description": "Smart Outlet",
+    "label": "39349 / ZW1002",
+    "manufacturer": "Honeywell"
+  },
+  "0x0039:0x4952:0x3135": {
+    "description": "In-Wall Smart Switch",
+    "label": "39348 / ZW4008",
+    "manufacturer": "Honeywell"
+  },
+  "0x0039:0x4952:0x3137": {
+    "description": "In-Wall Smart Toggle Switch",
+    "label": "39354",
+    "manufacturer": "Honeywell"
+  },
+  "0x0039:0x4f50:0x3032": {
+    "description": "Plug-in Outdoor Smart Switch ZW4201 / 39346",
+    "label": "Plug-in Outdoor Smart Switch",
+    "manufacturer": "Honeywell"
+  },
+  "0x0039:0x4f50:0x3034": {
+    "description": "Plug-in Outdoor Smart Switch",
+    "label": "39363 / ZW4203",
+    "manufacturer": "Honeywell"
+  },
+  "0x0039:0x5044:0x3033": {
+    "description": "Z-Wave Plug-in Smart Dimmer",
+    "label": "39339 / 39446 / ZW3107",
+    "manufacturer": "Honeywell"
+  },
+  "0x0039:0x5044:0x3038": {
+    "description": "Plug-in Dimmer (Single Plug)",
+    "label": "39443 / ZW3104",
+    "manufacturer": "Honeywell"
+  },
+  "0x0039:0x5052:0x3033": {
+    "description": "Plug-In Smart Switch (Dual Linked Outlets, Grounded)",
+    "label": "39342 / ZW4106",
+    "manufacturer": "Honeywell"
+  },
+  "0x0039:0x5052:0x3038": {
+    "description": "Plug-in Switch (Single Plug)",
+    "label": "39337 / ZW4103",
+    "manufacturer": "Honeywell"
+  },
+  "0x003b:0x0001:0x0468": {
+    "description": "Schlage Connect Smart Deadbolt",
+    "label": "BE468ZP",
+    "manufacturer": "Allegion"
+  },
+  "0x003b:0x0001:0x0469": {
+    "description": "Touchscreen Deadbolt Z-Wave Plus",
+    "label": "BE469ZP",
+    "manufacturer": "Allegion"
+  },
+  "0x003b:0x0003:0x6500": {
+    "description": "Schlage Z-Wave Mortise Lock",
+    "label": "S-6500F",
+    "manufacturer": "Allegion"
+  },
+  "0x003b:0x0004:0x0004": {
+    "description": "Nexia Bridge",
+    "label": "BR100",
+    "manufacturer": "Allegion"
+  },
+  "0x003b:0x0004:0x2109": {
+    "description": "J-Series by Schlage Z-Wave Keypad Deadbolt",
+    "label": "JBE109",
+    "manufacturer": "Allegion"
+  },
+  "0x003b:0x6341:0x5044": {
+    "description": "Touchscreen Deadbolt",
+    "label": "BE469",
+    "manufacturer": "Allegion"
+  },
+  "0x003b:0x6349:0x5044": {
+    "description": "Touchscreen Deadbolt",
+    "label": "BE468",
+    "manufacturer": "Allegion"
+  },
+  "0x003b:0x634b:0x5044": {
+    "description": "Keypad Deadbolt",
+    "label": "BE369",
+    "manufacturer": "Allegion"
+  },
+  "0x003b:0x634b:0x504c": {
+    "description": "Connected Keypad with Lever",
+    "label": "CKPD FE599",
+    "manufacturer": "Allegion"
+  },
+  "0x0040:0x0001:0x0100": {
+    "description": "Remote Control",
+    "label": "LRC14",
+    "manufacturer": "Novar Electrical Devices and Systems (EDS)"
+  },
+  "0x0040:0x0002:0x0101": {
+    "description": "1G Battery Controller",
+    "label": "LIB1",
+    "manufacturer": "Novar Electrical Devices and Systems (EDS)"
+  },
+  "0x0040:0x0002:0x0102": {
+    "description": "2G Battery Controller",
+    "label": "LIB2",
+    "manufacturer": "Novar Electrical Devices and Systems (EDS)"
+  },
+  "0x0040:0x0003:0x0101": {
+    "description": "1G Mains Controller",
+    "label": "LIM1H",
+    "manufacturer": "Novar Electrical Devices and Systems (EDS)"
+  },
+  "0x0040:0x0003:0x0102": {
+    "description": "2G Mains Controller",
+    "label": "LIM2",
+    "manufacturer": "Novar Electrical Devices and Systems (EDS)"
+  },
+  "0x0040:0x0004:0x0101": {
+    "description": "1G 300W Dimmer",
+    "label": "LDM31",
+    "manufacturer": "Novar Electrical Devices and Systems (EDS)"
+  },
+  "0x0040:0x0004:0x0102": {
+    "description": "MK Honeywell Astral 2 Load Wall Dimmer - LDM32UC",
+    "label": "LDM32",
+    "manufacturer": "Novar Electrical Devices and Systems (EDS)"
+  },
+  "0x0040:0x0004:0x0201": {
+    "description": "1G 600W Dimmer",
+    "label": "LDM61",
+    "manufacturer": "Novar Electrical Devices and Systems (EDS)"
+  },
+  "0x0040:0x0005:0x0101": {
+    "description": "1G Switch",
+    "label": "LSM11H",
+    "manufacturer": "Novar Electrical Devices and Systems (EDS)"
+  },
+  "0x0040:0x0005:0x0102": {
+    "description": "2G Switch",
+    "label": "LSM12",
+    "manufacturer": "Astral"
+  },
+  "0x0040:0x0301:0x0100": {
+    "description": "Remote Control",
+    "label": "LRC14",
+    "manufacturer": "Novar Electrical Devices and Systems (EDS)"
+  },
+  "0x0040:0x0302:0x0101": {
+    "description": "1G Battery Controller",
+    "label": "LIB1",
+    "manufacturer": "Novar Electrical Devices and Systems (EDS)"
+  },
+  "0x0040:0x0302:0x0102": {
+    "description": "2G Battery Controller",
+    "label": "LIB2",
+    "manufacturer": "Novar Electrical Devices and Systems (EDS)"
+  },
+  "0x0040:0x0303:0x0101": {
+    "description": "1G Mains Controller",
+    "label": "LIM1H",
+    "manufacturer": "Novar Electrical Devices and Systems (EDS)"
+  },
+  "0x0040:0x0303:0x0102": {
+    "description": "2G Mains Controller",
+    "label": "LIM2",
+    "manufacturer": "Novar Electrical Devices and Systems (EDS)"
+  },
+  "0x0040:0x0304:0x0101": {
+    "description": "1G 300W Dimmer",
+    "label": "LDM31",
+    "manufacturer": "Novar Electrical Devices and Systems (EDS)"
+  },
+  "0x0040:0x0304:0x0102": {
+    "description": "MK Honeywell Astral 2 Load Wall Dimmer - LDM32UC",
+    "label": "LDM32",
+    "manufacturer": "Novar Electrical Devices and Systems (EDS)"
+  },
+  "0x0040:0x0304:0x0201": {
+    "description": "1G 600W Dimmer",
+    "label": "LDM61",
+    "manufacturer": "Novar Electrical Devices and Systems (EDS)"
+  },
+  "0x0040:0x0305:0x0101": {
+    "description": "1G Switch",
+    "label": "LSM11H",
+    "manufacturer": "Novar Electrical Devices and Systems (EDS)"
+  },
+  "0x0040:0x0305:0x0102": {
+    "description": "2G Switch",
+    "label": "LSM12",
+    "manufacturer": "Astral"
+  },
+  "0x0040:0x0801:0x0100": {
+    "description": "Remote Control",
+    "label": "LRC14",
+    "manufacturer": "Novar Electrical Devices and Systems (EDS)"
+  },
+  "0x0040:0x0802:0x0101": {
+    "description": "1G Battery Controller",
+    "label": "LIB1",
+    "manufacturer": "Novar Electrical Devices and Systems (EDS)"
+  },
+  "0x0040:0x0802:0x0102": {
+    "description": "2G Battery Controller",
+    "label": "LIB2",
+    "manufacturer": "Novar Electrical Devices and Systems (EDS)"
+  },
+  "0x0040:0x0803:0x0101": {
+    "description": "1G Mains Controller",
+    "label": "LIM1H",
+    "manufacturer": "Novar Electrical Devices and Systems (EDS)"
+  },
+  "0x0040:0x0803:0x0102": {
+    "description": "2G Mains Controller",
+    "label": "LIM2",
+    "manufacturer": "Novar Electrical Devices and Systems (EDS)"
+  },
+  "0x0040:0x0804:0x0101": {
+    "description": "1G 300W Dimmer",
+    "label": "LDM31",
+    "manufacturer": "Novar Electrical Devices and Systems (EDS)"
+  },
+  "0x0040:0x0804:0x0102": {
+    "description": "MK Honeywell Astral 2 Load Wall Dimmer - LDM32UC",
+    "label": "LDM32",
+    "manufacturer": "Novar Electrical Devices and Systems (EDS)"
+  },
+  "0x0040:0x0804:0x0201": {
+    "description": "1G 600W Dimmer",
+    "label": "LDM61",
+    "manufacturer": "Novar Electrical Devices and Systems (EDS)"
+  },
+  "0x0040:0x0805:0x0101": {
+    "description": "1G Switch",
+    "label": "LSM11H",
+    "manufacturer": "Novar Electrical Devices and Systems (EDS)"
+  },
+  "0x0040:0x0805:0x0102": {
+    "description": "2G Switch",
+    "label": "LSM12",
+    "manufacturer": "Astral"
+  },
+  "0x0040:0x0901:0x0100": {
+    "description": "Remote Control",
+    "label": "LRC14",
+    "manufacturer": "Novar Electrical Devices and Systems (EDS)"
+  },
+  "0x0040:0x0902:0x0101": {
+    "description": "1G Battery Controller",
+    "label": "LIB1",
+    "manufacturer": "Novar Electrical Devices and Systems (EDS)"
+  },
+  "0x0040:0x0902:0x0102": {
+    "description": "2G Battery Controller",
+    "label": "LIB2",
+    "manufacturer": "Novar Electrical Devices and Systems (EDS)"
+  },
+  "0x0040:0x0903:0x0101": {
+    "description": "1G Mains Controller",
+    "label": "LIM1H",
+    "manufacturer": "Novar Electrical Devices and Systems (EDS)"
+  },
+  "0x0040:0x0903:0x0102": {
+    "description": "2G Mains Controller",
+    "label": "LIM2",
+    "manufacturer": "Novar Electrical Devices and Systems (EDS)"
+  },
+  "0x0040:0x0904:0x0101": {
+    "description": "1G 300W Dimmer",
+    "label": "LDM31",
+    "manufacturer": "Novar Electrical Devices and Systems (EDS)"
+  },
+  "0x0040:0x0904:0x0102": {
+    "description": "MK Honeywell Astral 2 Load Wall Dimmer - LDM32UC",
+    "label": "LDM32",
+    "manufacturer": "Novar Electrical Devices and Systems (EDS)"
+  },
+  "0x0040:0x0904:0x0201": {
+    "description": "1G 600W Dimmer",
+    "label": "LDM61",
+    "manufacturer": "Novar Electrical Devices and Systems (EDS)"
+  },
+  "0x0040:0x0905:0x0101": {
+    "description": "1G Switch",
+    "label": "LSM11H",
+    "manufacturer": "Novar Electrical Devices and Systems (EDS)"
+  },
+  "0x0040:0x0905:0x0102": {
+    "description": "2G Switch",
+    "label": "LSM12",
+    "manufacturer": "Astral"
+  },
+  "0x0047:0x0005:0x5400": {
+    "description": "Z-Wave to RTS Interface II - ZRTSII",
+    "label": "1870203",
+    "manufacturer": "Somfy"
+  },
+  "0x0047:0x1e54:0x4841": {
+    "description": "Somfy TaHomA Z-Wave Controller",
+    "label": "TAHOM",
+    "manufacturer": "Somfy"
+  },
+  "0x0047:0x2018:0x1805": {
+    "description": "Blind-curtain motor controller",
+    "label": "SY-IOT101",
+    "manufacturer": "Somfy"
+  },
+  "0x0047:0x3001:0x0b01": {
+    "description": "Z-WAVE2RTS Interface",
+    "label": "Z2RTSEU-5",
+    "manufacturer": "Somfy"
+  },
+  "0x0047:0x474c:0x5901": {
+    "description": "Somfy Z-Wave to Glydea",
+    "label": "1870228",
+    "manufacturer": "Somfy"
+  },
+  "0x0047:0x4c54:0x0001": {
+    "description": "ZDMI/ILT Z-Wave Interface",
+    "label": "ZDMI 1870171",
+    "manufacturer": "Somfy"
+  },
+  "0x0047:0x5a52:0x5400": {
+    "description": "Z-Wave to RTS Interface Controller",
+    "label": "ZRTSI",
+    "manufacturer": "Somfy"
+  },
+  "0x0047:0x5a52:0x5401": {
+    "description": "Z-Wave to RTS Interface Virtual Node",
+    "label": "ZRTSI-VNODE",
+    "manufacturer": "Somfy"
+  },
+  "0x0047:0x5a52:0x5402": {
+    "description": "Z-Wave to RTS Interface Virtual Node",
+    "label": "ZRTSI-VNODE",
+    "manufacturer": "Somfy"
+  },
+  "0x0047:0x5a52:0x5403": {
+    "description": "Z-Wave to RTS Interface Virtual Node",
+    "label": "ZRTSI-VNODE",
+    "manufacturer": "Somfy"
+  },
+  "0x0047:0x5a52:0x5404": {
+    "description": "Z-Wave to RTS Interface Virtual Node",
+    "label": "ZRTSI-VNODE",
+    "manufacturer": "Somfy"
+  },
+  "0x0047:0x5a52:0x5405": {
+    "description": "Z-Wave to RTS Interface Virtual Node",
+    "label": "ZRTSI-VNODE",
+    "manufacturer": "Somfy"
+  },
+  "0x0047:0x5a52:0x5406": {
+    "description": "Z-Wave to RTS Interface Virtual Node",
+    "label": "ZRTSI-VNODE",
+    "manufacturer": "Somfy"
+  },
+  "0x0047:0x5a52:0x5407": {
+    "description": "Z-Wave to RTS Interface Virtual Node",
+    "label": "ZRTSI-VNODE",
+    "manufacturer": "Somfy"
+  },
+  "0x0047:0x5a52:0x5408": {
+    "description": "Z-Wave to RTS Interface Virtual Node",
+    "label": "ZRTSI-VNODE",
+    "manufacturer": "Somfy"
+  },
+  "0x0047:0x5a52:0x5409": {
+    "description": "Z-Wave to RTS Interface Virtual Node",
+    "label": "ZRTSI-VNODE",
+    "manufacturer": "Somfy"
+  },
+  "0x0047:0x5a52:0x540a": {
+    "description": "Z-Wave to RTS Interface Virtual Node",
+    "label": "ZRTSI-VNODE",
+    "manufacturer": "Somfy"
+  },
+  "0x0047:0x5a52:0x540b": {
+    "description": "Z-Wave to RTS Interface Virtual Node",
+    "label": "ZRTSI-VNODE",
+    "manufacturer": "Somfy"
+  },
+  "0x0047:0x5a52:0x540c": {
+    "description": "Z-Wave to RTS Interface Virtual Node",
+    "label": "ZRTSI-VNODE",
+    "manufacturer": "Somfy"
+  },
+  "0x0047:0x5a52:0x540d": {
+    "description": "Z-Wave to RTS Interface Virtual Node",
+    "label": "ZRTSI-VNODE",
+    "manufacturer": "Somfy"
+  },
+  "0x0047:0x5a52:0x540e": {
+    "description": "Z-Wave to RTS Interface Virtual Node",
+    "label": "ZRTSI-VNODE",
+    "manufacturer": "Somfy"
+  },
+  "0x0047:0x5a52:0x540f": {
+    "description": "Z-Wave to RTS Interface Virtual Node",
+    "label": "ZRTSI-VNODE",
+    "manufacturer": "Somfy"
+  },
+  "0x0047:0x5a52:0x5410": {
+    "description": "Z-Wave to RTS Interface Virtual Node",
+    "label": "ZRTSI-VNODE",
+    "manufacturer": "Somfy"
+  },
+  "0x004f:0x0000:0x0000": {
+    "description": "Touch Panel- 4 Dimmers plus 4 ON-OFF- 5 Scenes",
+    "label": "FXA-0404",
+    "manufacturer": "Flex Automation"
+  },
+  "0x004f:0x0001:0x0001": {
+    "description": "Micro Dimmer",
+    "label": "FX-D211",
+    "manufacturer": "Flex Automation"
+  },
+  "0x004f:0x0001:0x0015": {
+    "description": "Micro-Smart Module for AC Motors",
+    "label": "FXS-M08",
+    "manufacturer": "Flex Automation"
+  },
+  "0x004f:0x0002:0x0001": {
+    "description": "Micro Relay",
+    "label": "FX-R211",
+    "manufacturer": "Flex Automation"
+  },
+  "0x004f:0x0003:0x0008": {
+    "description": "Smart dimmer",
+    "label": "FX-D67",
+    "manufacturer": "Flex Automation"
+  },
+  "0x004f:0x0004:0x0002": {
+    "description": "Meter Switch",
+    "label": "FX-S69",
+    "manufacturer": "Flex Automation"
+  },
+  "0x004f:0x5102:0x0103": {
+    "description": "Relay FIT Triplo",
+    "label": "FXR-5013",
+    "manufacturer": "Flex Automation"
+  },
+  "0x0059:0x0000:0x0001": {
+    "description": "Water Meter-ZW (SWM301)",
+    "label": "NU2030101000",
+    "manufacturer": "Secure Meters (UK) Ltd."
+  },
+  "0x0059:0x0001:0x0003": {
+    "description": "Battery Powered Wall Thermostat",
+    "label": "HRT4-ZW / SRT321",
+    "manufacturer": "Secure Meters (UK) Ltd."
+  },
+  "0x0059:0x0001:0x0004": {
+    "description": "Secure Z-Wave Room Thermostat",
+    "label": "SRT323",
+    "manufacturer": "Secure Meters (UK) Ltd."
+  },
+  "0x0059:0x0001:0x0005": {
+    "description": "Battery Powered Wall Thermostat",
+    "label": "SRT321",
+    "manufacturer": "Secure Meters (UK) Ltd."
+  },
+  "0x0059:0x0002:0x0002": {
+    "description": "Timeswitch",
+    "label": "C17-ZW",
+    "manufacturer": "Secure Meters (UK) Ltd."
+  },
+  "0x0059:0x0003:0x0001": {
+    "description": "Thermostat Receiver",
+    "label": "SRT322",
+    "manufacturer": "Secure Meters (UK) Ltd."
+  },
+  "0x0059:0x0003:0x0002": {
+    "description": "Two Channel Boiler Actuator",
+    "label": "SSR-302",
+    "manufacturer": "Secure Meters (UK) Ltd."
+  },
+  "0x0059:0x0003:0x0005": {
+    "description": "Two Channel Boiler Actuator",
+    "label": "SSR-302",
+    "manufacturer": "Secure Meters (UK) Ltd."
+  },
+  "0x0059:0x0003:0x0006": {
+    "description": "Two Channel Boiler Actuator",
+    "label": "SSR-302",
+    "manufacturer": "Secure Meters (UK) Ltd."
+  },
+  "0x0059:0x0004:0x0001": {
+    "description": "7 Day Room Thermostat",
+    "label": "C17-ZW",
+    "manufacturer": "Secure Meters (UK) Ltd."
+  },
+  "0x0059:0x0005:0x0001": {
+    "description": "Z-Wave home energy meter",
+    "label": "S123XXXR",
+    "manufacturer": "Secure Meters (UK) Ltd."
+  },
+  "0x0059:0x0005:0x0005": {
+    "description": "Generation Meter Series P",
+    "label": "P123XXXR",
+    "manufacturer": "Secure Meters (UK) Ltd."
+  },
+  "0x0059:0x000d:0x0001": {
+    "description": "Secure Temperature Sensor",
+    "label": "SES301",
+    "manufacturer": "Secure Meters (UK) Ltd."
+  },
+  "0x0059:0x000d:0x0002": {
+    "description": "Temperature sensor",
+    "label": "SES 302",
+    "manufacturer": "Secure Meters (UK) Ltd."
+  },
+  "0x0059:0x000d:0x0003": {
+    "description": "Temperature and humidity sensor",
+    "label": "SES 303",
+    "manufacturer": "Secure Meters (UK) Ltd."
+  },
+  "0x0059:0x000e:0x0001": {
+    "description": "SSP",
+    "label": "SSP 301",
+    "manufacturer": "Secure Meters (UK) Ltd."
+  },
+  "0x0059:0x000e:0x0002": {
+    "description": "SSP",
+    "label": "SSP 301 ANZ",
+    "manufacturer": "Secure Meters (UK) Ltd."
+  },
+  "0x0059:0x000f:0x0001": {
+    "description": "Z-Wave Module for Water Meter",
+    "label": "SWM301",
+    "manufacturer": "Secure Meters (UK) Ltd."
+  },
+  "0x0059:0x0010:0x0001": {
+    "description": "RF Countdown Timer",
+    "label": "SIR 321",
+    "manufacturer": "Secure Meters (UK) Ltd."
+  },
+  "0x0059:0x0010:0x0002": {
+    "description": "RF Countdown Timer",
+    "label": "SIR 321",
+    "manufacturer": "Secure Meters (UK) Ltd."
+  },
+  "0x0059:0x0010:0x0003": {
+    "description": "SIR 321",
+    "label": "MAX10Y-376",
+    "manufacturer": "Secure Meters (UK) Ltd."
+  },
+  "0x0059:0x0011:0x0001": {
+    "description": "Switch Meter Plugin",
+    "label": "SSP302",
+    "manufacturer": "Secure Meters (UK) Ltd."
+  },
+  "0x0059:0x0011:0x0002": {
+    "description": "Secure Smart Plug 302",
+    "label": "SSP 302 ANZ",
+    "manufacturer": "Secure Meters (UK) Ltd."
+  },
+  "0x0059:0x0013:0x0001": {
+    "description": "Beanbag Thermostat",
+    "label": "BBK001-Z00",
+    "manufacturer": "Secure Meters (UK) Ltd."
+  },
+  "0x0059:0x0014:0x0001": {
+    "description": "Beanbag Thermostat Receiver",
+    "label": "MAX10Z-737",
+    "manufacturer": "Secure Meters (UK) Ltd."
+  },
+  "0x0059:0x0015:0x0001": {
+    "description": "Beanbag Thermostat",
+    "label": "BBK001-Z00",
+    "manufacturer": "Secure Meters (UK) Ltd."
+  },
+  "0x0060:0x0000:0x0000": {
+    "description": "Dimmer Plugin",
+    "label": "AD130",
+    "manufacturer": "Everspring"
+  },
+  "0x0060:0x0000:0x0001": {
+    "description": "Flood Sensor",
+    "label": "ST812",
+    "manufacturer": "Everspring"
+  },
+  "0x0060:0x0000:0x0002": {
+    "description": "Smoke Sensor",
+    "label": "SF813",
+    "manufacturer": "Everspring"
+  },
+  "0x0060:0x0001:0x0001": {
+    "description": "Motion Detector",
+    "label": "HSP02 / SP103",
+    "manufacturer": "Everspring"
+  },
+  "0x0060:0x0001:0x0002": {
+    "description": "Motion Detector",
+    "label": "SP814",
+    "manufacturer": "Everspring"
+  },
+  "0x0060:0x0001:0x0003": {
+    "description": "Motion Detector",
+    "label": "HSP02 / SP103",
+    "manufacturer": "Everspring"
+  },
+  "0x0060:0x0001:0x0004": {
+    "description": "PET IMMUNE PIR MOTION DETECTOR",
+    "label": "SP815",
+    "manufacturer": "Everspring"
+  },
+  "0x0060:0x0001:0x0005": {
+    "description": "SP816 Motion Sensor",
+    "label": "SP816",
+    "manufacturer": "Everspring"
+  },
+  "0x0060:0x0001:0x0006": {
+    "description": "SP817 Motion Sensor",
+    "label": "SP817",
+    "manufacturer": "Everspring"
+  },
+  "0x0060:0x0002:0x0001": {
+    "description": "Door/Window Contact",
+    "label": "SM103",
+    "manufacturer": "Everspring"
+  },
+  "0x0060:0x0002:0x0002": {
+    "description": "Door/Window Contact",
+    "label": "HSM02",
+    "manufacturer": "Everspring"
+  },
+  "0x0060:0x0002:0x0003": {
+    "description": "Door/Window Detector",
+    "label": "SM810",
+    "manufacturer": "Everspring"
+  },
+  "0x0060:0x0003:0x0001": {
+    "description": "Indoor Dimmer Plug",
+    "label": "AD142",
+    "manufacturer": "Everspring"
+  },
+  "0x0060:0x0003:0x0002": {
+    "description": "In-Wall Dimmer Module",
+    "label": "AD146-0",
+    "manufacturer": "Everspring"
+  },
+  "0x0060:0x0003:0x0003": {
+    "description": "Z-Wave Dimmer Plug",
+    "label": "AD147",
+    "manufacturer": "Everspring"
+  },
+  "0x0060:0x0004:0x0001": {
+    "description": "Everspring Lamp Holder / Lamp Module",
+    "label": "AN142/ AN145 / AN148 / AN157",
+    "manufacturer": "Everspring"
+  },
+  "0x0060:0x0004:0x0002": {
+    "description": "Switch Meter Plugin",
+    "label": "AN158",
+    "manufacturer": "Everspring"
+  },
+  "0x0060:0x0004:0x0005": {
+    "description": "Metering Power Switch",
+    "label": "AN163",
+    "manufacturer": "Everspring"
+  },
+  "0x0060:0x0004:0x0006": {
+    "description": "Mini Plug Switch with Metering (Gen5)",
+    "label": "AN181",
+    "manufacturer": "Everspring"
+  },
+  "0x0060:0x0004:0x0007": {
+    "description": "Switch without metering",
+    "label": "AN180",
+    "manufacturer": "Everspring"
+  },
+  "0x0060:0x0004:0x0008": {
+    "description": "In-Wall Switch Module",
+    "label": "HAN02",
+    "manufacturer": "Everspring"
+  },
+  "0x0060:0x0004:0x000b": {
+    "description": "Mini plug with metering",
+    "label": "AN184",
+    "manufacturer": "Everspring"
+  },
+  "0x0060:0x0004:0x000c": {
+    "description": "ON/OFF PLUG",
+    "label": "AN186",
+    "manufacturer": "Everspring"
+  },
+  "0x0060:0x0004:0x000d": {
+    "description": "Metering Plug",
+    "label": "AN188",
+    "manufacturer": "Everspring"
+  },
+  "0x0060:0x0004:0x000e": {
+    "description": "Dual Relay In-Wall Module",
+    "label": "AN196-0",
+    "manufacturer": "Everspring"
+  },
+  "0x0060:0x0006:0x0001": {
+    "description": "Temperature and Humidity Sensor",
+    "label": "ST814",
+    "manufacturer": "Everspring"
+  },
+  "0x0060:0x0007:0x0001": {
+    "description": "Illumination Sensor",
+    "label": "ST815",
+    "manufacturer": "Everspring"
+  },
+  "0x0060:0x0009:0x0001": {
+    "description": "Door Bell",
+    "label": "TSE03",
+    "manufacturer": "Everspring"
+  },
+  "0x0060:0x000a:0x0001": {
+    "description": "Door Bell Pushbutton",
+    "label": "TAC06-JOEL",
+    "manufacturer": "Everspring"
+  },
+  "0x0060:0x000a:0x0002": {
+    "description": "PANIC BUTTON",
+    "label": "AC136",
+    "manufacturer": "Everspring"
+  },
+  "0x0060:0x000a:0x0003": {
+    "description": "WALL SWITCH-ON/OFF BUTTON",
+    "label": "AC137",
+    "manufacturer": "Everspring"
+  },
+  "0x0060:0x000b:0x0001": {
+    "description": "Flood Sensor",
+    "label": "ST812",
+    "manufacturer": "Everspring"
+  },
+  "0x0060:0x000c:0x0001": {
+    "description": "Siren",
+    "label": "SE812",
+    "manufacturer": "Everspring"
+  },
+  "0x0060:0x000c:0x0003": {
+    "description": "Indoor Voice Siren",
+    "label": "SE813",
+    "manufacturer": "Everspring"
+  },
+  "0x0060:0x000d:0x0001": {
+    "description": "Smoke Sensor",
+    "label": "SF812",
+    "manufacturer": "Everspring"
+  },
+  "0x0060:0x000e:0x0001": {
+    "description": "Z-Wave Gateway w/ Casiva Server Solution",
+    "label": "SC102",
+    "manufacturer": "Everspring"
+  },
+  "0x0060:0x0010:0x0001": {
+    "description": "In-Wall Remote Insert",
+    "label": "HAC01",
+    "manufacturer": "Everspring"
+  },
+  "0x0060:0x0011:0x0001": {
+    "description": "In-Wall Switch Module",
+    "label": "HAN02",
+    "manufacturer": "Everspring"
+  },
+  "0x0060:0x0011:0x0002": {
+    "description": "In-Wall Switch Module",
+    "label": "HAN02",
+    "manufacturer": "Everspring"
+  },
+  "0x0060:0x0012:0x0001": {
+    "description": "Z-Wave Floodlight with Motion Detector",
+    "label": "EH403",
+    "manufacturer": "Everspring"
+  },
+  "0x0060:0x0015:0x0001": {
+    "description": "Thermostatic Radiator Valve",
+    "label": "AC301",
+    "manufacturer": "Everspring"
+  },
+  "0x0060:0x0101:0x0001": {
+    "description": "Motion Detector",
+    "label": "HSP02 / SP103",
+    "manufacturer": "Everspring"
+  },
+  "0x0060:0x0104:0x0001": {
+    "description": "Everspring Lamp Holder / Lamp Module",
+    "label": "AN142/ AN145 / AN148 / AN157",
+    "manufacturer": "Everspring"
+  },
+  "0x0060:0x0202:0x0001": {
+    "description": "Door/Window Contact",
+    "label": "HSM02",
+    "manufacturer": "Everspring"
+  },
+  "0x0060:0x0400:0x0001": {
+    "description": "Everspring Lamp Holder / Lamp Module",
+    "label": "AN142/ AN145 / AN148 / AN157",
+    "manufacturer": "Everspring"
+  },
+  "0x0063:0x0004:0x3031": {
+    "description": "GE Z-Wave Plug-in Outdoor Smart Switch",
+    "label": "12720 / ZW4201",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x0507:0x0403": {
+    "description": "Fan Control",
+    "label": "10974 / ZW4002",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4450:0x3030": {
+    "description": "Lamp Module",
+    "label": "ZW3101",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4450:0x3031": {
+    "description": "Energy Monitoring Lamp Dimmer",
+    "label": "ZW3102",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4457:0x0003": {
+    "description": "In-Wall Decora Style Incandescent Light Dimmer, No Neutral, White, (Included Only in 45613 kit)",
+    "label": "45607 / ZW3002",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4457:0x3033": {
+    "description": "2-Way Dimmer Switch",
+    "label": "45607",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4457:0x3230": {
+    "description": "2-Way Dimmer Switch",
+    "label": "45606",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4843:0x0037": {
+    "description": "2 Button Hub Remote",
+    "label": "34184 / ZW5307",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4843:0x3031": {
+    "description": "1 Scene Z-Wave controller",
+    "label": "34172 / ZW5304",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4843:0x3033": {
+    "description": "2 Scene Z-Wave controller",
+    "label": "34174 / ZW5305",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4843:0x3035": {
+    "description": "4 Scene Z-Wave controller",
+    "label": "34176 / ZW5306",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4843:0x3133": {
+    "description": "2 Button Hub/Panel Remote",
+    "label": "37792 / ZW5307",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4843:0x3136": {
+    "description": "Portable Remote, 2 Button",
+    "label": "53829 / ZW5313",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4843:0x3138": {
+    "description": "Portable Remote, 4 Button",
+    "label": "53831 / ZW5314",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4944:0x3031": {
+    "description": "In-Wall Dimmer",
+    "label": "12724 / ZW3003",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4944:0x3032": {
+    "description": "In-Wall Dimmer",
+    "label": "12725",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4944:0x3033": {
+    "description": "In-Wall Smart Dimmer",
+    "label": "12729 / ZW3004",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4944:0x3034": {
+    "description": "In-Wall Smart Fan Control",
+    "label": "12730  / ZW4002",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4944:0x3035": {
+    "description": "GE In-Wall Toggle Dimmer, Almond",
+    "label": "12733",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4944:0x3036": {
+    "description": "GE In-Wall Dimmer, Toggle, White, No Neutral",
+    "label": "12734",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4944:0x3037": {
+    "description": "GE In-Wall Dimmer, Toggle, Almond, No Neutral",
+    "label": "12735",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4944:0x3038": {
+    "description": "In-Wall Dimmer Switch",
+    "label": "14294 / ZW3005",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4944:0x3039": {
+    "description": "In-Wall 1000W Incandescent Smart Dimmer",
+    "label": "14299",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4944:0x3130": {
+    "description": "In-Wall Dimmer Switch",
+    "label": "14295",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4944:0x3131": {
+    "description": "In-Wall Smart Fan Control",
+    "label": "14287 / ZW4002",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4944:0x3135": {
+    "description": "In-Wall Dimmer",
+    "label": "14321",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4944:0x3136": {
+    "description": "In-Wall Smart Dimmer (1000W)",
+    "label": "14326",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4944:0x3137": {
+    "description": "Jasco In-Wall Smart Dimmer (White Toggle)",
+    "label": "14322",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4944:0x3138": {
+    "description": "In-Wall Smart Fan Control",
+    "label": "14314",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4944:0x3232": {
+    "description": "In-Wall Smart Fan Control",
+    "label": "14314 / ZW4002",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4944:0x3233": {
+    "description": "In-Wall Touch Sensing Dimmer",
+    "label": "14289 / ZW3009",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4944:0x3235": {
+    "description": "GE Enbrighten Z-Wave Plus Smart Dimmer",
+    "label": "46203",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4944:0x3236": {
+    "description": "In-Wall Smart Dimmer",
+    "label": "14321 / 46564 / ZW3010",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4944:0x3237": {
+    "description": "In-Wall Smart Toggle Dimmer",
+    "label": "14295 / 46204 / ZW3011",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4944:0x3238": {
+    "description": "In-Wall Smart Toggle Dimmer",
+    "label": "14322 / 46565 / ZW3011",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4944:0x3330": {
+    "description": "0-10V In-Wall Smart Dimmer (ICP) (120/277)",
+    "label": "43105 / ZW3014",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4944:0x3332": {
+    "description": "0-10V In-Wall Smart Dimmer (ICP) (120/277)",
+    "label": "43107 / ZW3015",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4944:0x3333": {
+    "description": "Enbrighten Z-Wave Plus In-Wall Smart Dimmer, No Neutral, LED-CFL, White and Light Almond Paddles, 700S",
+    "label": "52252 / 52253 / ZW3012",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4944:0x3337": {
+    "description": "In-Wall 3-Speed Fan Control",
+    "label": "55258 / ZW4002",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4944:0x3338": {
+    "description": "In-Wall 3-Speed Fan Control",
+    "label": "55259 / ZW4002",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4944:0x3339": {
+    "description": "In-Wall Smart Dimmer",
+    "label": "39351 / 54897 / 54898/ ZW301",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x494d:0x3031": {
+    "description": "In-Wall Smart Motion Switch",
+    "label": "24770 / ZW4006",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x494d:0x3032": {
+    "description": "In-Wall Smart Motion Switch",
+    "label": "26931 / ZW4006",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x494d:0x3033": {
+    "description": "In-Wall Smart Motion Dimmer",
+    "label": "26932 / 26933 / ZW3008",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x494d:0x3034": {
+    "description": "In-Wall Smart Motion Dimmer",
+    "label": "26932 / 26933 / ZW3008",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4952:0x3031": {
+    "description": "Smart Outlet",
+    "label": "ZW1001",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4952:0x3032": {
+    "description": "On/Off Relay Switch",
+    "label": "12722 / ZW4005",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4952:0x3033": {
+    "description": "Wireless Lighting Control Smart Toggle Switch",
+    "label": "12727 / ZW4003",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4952:0x3034": {
+    "description": "GE In-Wall Toggle, Almond",
+    "label": "12731",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4952:0x3035": {
+    "description": "In-Wall Smart Outlet",
+    "label": "14286 / ZW1001",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4952:0x3036": {
+    "description": "In-Wall Paddle Switch",
+    "label": "14291 / ZW4005",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4952:0x3037": {
+    "description": "In-Wall Toggle Switch",
+    "label": "14292",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4952:0x3038": {
+    "description": "In-Wall Smart Toggle Switch (Lt. Almond)",
+    "label": "14293 / ZW4003",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4952:0x3039": {
+    "description": "In-Wall Smart Outlet",
+    "label": "14313 / ZW1001",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4952:0x3130": {
+    "description": "Jasco 3-way Light Switch",
+    "label": "Jasco 14318",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4952:0x3131": {
+    "description": "In-Wall Smart Toggle Switch",
+    "label": "14319 / ZW4003",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4952:0x3132": {
+    "description": "In-Wall Smart Toggle Switch",
+    "label": "14320 / ZW4003",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4952:0x3133": {
+    "description": "In-Wall Tamper Resistant Smart Outlet",
+    "label": "14288 / ZW1002",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4952:0x3134": {
+    "description": "In-Wall Tamper Resistant Smart Outlet",
+    "label": "14288 / ZW1002",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4952:0x3135": {
+    "description": "GE Quick-fit Smart In-Wall Paddle Switch",
+    "label": "46201",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4952:0x3136": {
+    "description": "In-Wall Smart Switch",
+    "label": "46562 / ZW4008",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4952:0x3137": {
+    "description": "GE Enbrighten Z-Wave Plus Smart Switch",
+    "label": "46202",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4952:0x3138": {
+    "description": "In-Wall Smart Toggle Switch",
+    "label": "14319 / 46563 / ZW4009",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4952:0x3139": {
+    "description": "In-Wall Smart Switch (120/277VAC)",
+    "label": "43072 / ZW4008DV",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4952:0x3185": {
+    "description": "In-Wall Paddle Switch",
+    "label": "14291 / ZW4005",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4952:0x3231": {
+    "description": "In-Wall Smart Toggle Switch (120/277VAC)",
+    "label": "43074 / ZW4009DV",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4952:0x3234": {
+    "description": "In-Wall Tamper Resistant Smart Outlet",
+    "label": "55256 / ZW1002",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4952:0x3235": {
+    "description": "In-Wall Tamper Resistant Smart Outlet",
+    "label": "55257 / ZW1002",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4952:0x3237": {
+    "description": "In-Wall Smart Switch",
+    "label": "39348 / 54890 / 54891 / ZW4008",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4952:0x3238": {
+    "description": "In-Wall Smart Toggle Switch",
+    "label": "39354 / 54912 / ZW4009",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4953:0x3031": {
+    "description": "Hinge Pin Smart Door Sensor",
+    "label": "32562 / ZW4001",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4953:0x3032": {
+    "description": "Smart Door Sensor",
+    "label": "32563",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4953:0x3033": {
+    "description": "Portable Smart Multi Sensor",
+    "label": "35211/ZW6302",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4953:0x3034": {
+    "description": "Portable Smart Multi Sensor",
+    "label": "35530/ZW6302",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4953:0x3133": {
+    "description": "Portable Smart Motion Sensor",
+    "label": "34193/ZW6302",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4953:0x3134": {
+    "description": "Portable Smart Motion Sensor",
+    "label": "34194/ZW6302",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4953:0x3139": {
+    "description": "Slim Smart Door/Window Sensor",
+    "label": "38957/ZW6305",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4953:0x3231": {
+    "description": "Smart Flood/Freeze Sensor",
+    "label": "38959/ZW6306",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4953:0x3235": {
+    "description": "Slim Smart Door/Window Sensor",
+    "label": "43973/ZW6305",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4953:0x3236": {
+    "description": "Smart Flood/Freeze Sensor",
+    "label": "43985 / ZW6306",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4953:0x3238": {
+    "description": "Portable Smart Motion Sensor",
+    "label": "52251/ZW6307",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4953:0x3336": {
+    "description": "Slim Smart Door/Window Sensor",
+    "label": "52249/ZW6308",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4953:0x3430": {
+    "description": "Smart Flood/Freeze Sensor",
+    "label": "52247/ZW6309",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4c42:0x3031": {
+    "description": "Enbrighten 60W Dimmable Light Bulb",
+    "label": "35931",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4c42:0x3035": {
+    "description": "Z-Wave LED Light Bulb",
+    "label": "52190 / ZW7105",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4f44:0x3031": {
+    "description": "GE Z-Wave Wireless Smart Lighting and Appliance Control - 40 Amp",
+    "label": "ZW4004",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4f44:0x3032": {
+    "description": "Direct Wire Indoor/Outdoor Smart Switch",
+    "label": "14285",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4f50:0x3031": {
+    "description": "Outdoor Lighting Control Module",
+    "label": "45604",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4f50:0x3032": {
+    "description": "Weather Resistant Outdoor Switch",
+    "label": "Outdoor Switch",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4f50:0x3033": {
+    "description": "Plug-in Outdoor Smart Switch",
+    "label": "14311/ZW4201",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4f50:0x3034": {
+    "description": "Plug-in Outdoor Smart Switch",
+    "label": "14298 / ZW4202",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x4f50:0x3035": {
+    "description": "Plug-in Outdoor Smart Switch",
+    "label": "14325 / ZW4203",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x5042:0x4004": {
+    "description": "Direct Wire Indoor/Outdoor Smart Switch",
+    "label": "14285",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x5044:0x3031": {
+    "description": "Smart Dimmer",
+    "label": "12718 / ZW3101",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x5044:0x3032": {
+    "description": "GE Energy Monitoring Lamp Module",
+    "label": "45652",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x5044:0x3033": {
+    "description": "Plug-In Smart Dimmer (Dual Linked Outlets)",
+    "label": "14280 / ZW3107",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x5044:0x3035": {
+    "description": "Plug-in Smart Dimmer, Dual Outlet with Simultaneous Control",
+    "label": "14307",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x5044:0x3037": {
+    "description": "Plug-in Smart Dimmer (Single Plug)",
+    "label": "28166 / ZW3104",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x5044:0x3038": {
+    "description": "Plug-In Smart Dimmer",
+    "label": "28167 / ZW3104",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x5044:0x3039": {
+    "description": "Plug-in Smart Dimmer (Dual Plug)",
+    "label": "28170 / ZW3105",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x5044:0x3130": {
+    "description": "Plug-in Smart Dimmer (Single Plug)",
+    "label": "28171 / ZW3105",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x5044:0x3131": {
+    "description": "Plug-in Dual Smart Dimmer With 3.4A USB Charging",
+    "label": "28174",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x5044:0x3132": {
+    "description": "Plug-In Dual Smart Dimmer",
+    "label": "28175  / ZW3106",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x5044:0x3133": {
+    "description": "Plug-in Smart Dimmer (Dual Plug with Simultaneous Control)",
+    "label": "55251 / ZW3107",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x5044:0x3134": {
+    "description": "Plug-in Smart Dimmer (Dual Plug with Pass through Outlet)",
+    "label": "55252 / ZW3105",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x5052:0x3031": {
+    "description": "Fluorescent Light & Appliance Module",
+    "label": "45603",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x5052:0x3032": {
+    "description": "GE Appliance Module",
+    "label": "45653 / ZW4102",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x5052:0x3033": {
+    "description": "GE Plug in Smart Switch Zwave Plus",
+    "label": "Plug in Smart Switch",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x5052:0x3035": {
+    "description": "Plug-in Smart Switch, Dual Outlet with Simultaneous Control",
+    "label": "14309",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x5052:0x3037": {
+    "description": "Plug in Smart Switch",
+    "label": "GE 28169 / Jasco 28168",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x5052:0x3038": {
+    "description": "Plug in Smart Switch",
+    "label": "GE 28169 / Jasco 28168",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x5052:0x3039": {
+    "description": "Plug-in Smart Switch (Dual Plug)",
+    "label": "28172 / 28713 / ZW4104",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x5052:0x3130": {
+    "description": "Plug-in Smart Switch (Dual Plug)",
+    "label": "28172 / 28713 / ZW4104",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x5052:0x3131": {
+    "description": "Plug-in Dual Smart Switch",
+    "label": "28176 / ZW4105",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x5052:0x3132": {
+    "description": "GE Z-Wave Plus Wireless Smart Lighting Control Appliance Module",
+    "label": "28177",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x5052:0x3133": {
+    "description": "Plug-in Smart Switch (Dual Plug with Simultaneous Control)",
+    "label": "55249 / ZW4106",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x5052:0x3134": {
+    "description": "Plug-in Smart Switch (Dual Plug with Pass through Outlet)",
+    "label": "55250 / ZW4104",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x5250:0x3030": {
+    "description": "Fluorescent Light & Appliance Module",
+    "label": "45603",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x5250:0x3031": {
+    "description": "Energy Monitoring Appliance Module",
+    "label": "ZW4102",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x5250:0x3130": {
+    "description": "Outdoor Lighting Control Module",
+    "label": "45604",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x5252:0x3530": {
+    "description": "Duplex receptacle",
+    "label": "45605",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x5257:0x3533": {
+    "description": "On/Off Relay Switch",
+    "label": "45609",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x6363:0x3030": {
+    "description": "Fluorescent Light & Appliance Module",
+    "label": "ZW4101",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x6363:0x3130": {
+    "description": "Outdoor Lighting Control Module",
+    "label": "45604",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x6363:0x3533": {
+    "description": "On/Off Relay Switch",
+    "label": "45609",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x8008:0x5301": {
+    "description": "Battery Operated Keypad Secondary Controller, 4 Groups/Scenes",
+    "label": "45631 / ZW5301",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0063:0x8009:0x5303": {
+    "description": "Wireless Lighting Control Advanced Remote",
+    "label": "45633 / ZW5303",
+    "manufacturer": "GE/Jasco"
+  },
+  "0x0064:0x0001:0x0000": {
+    "description": "One Paddle Wall Dimmer Insert",
+    "label": "05433",
+    "manufacturer": "Reitz-Group.de"
+  },
+  "0x0064:0x1000:0x0003": {
+    "description": "Insert blind control",
+    "label": "06436",
+    "manufacturer": "Reitz-Group.de"
+  },
+  "0x0064:0x1000:0x0009": {
+    "description": "Switch",
+    "label": "ZME_05431",
+    "manufacturer": "Reitz-Group.de"
+  },
+  "0x0064:0x1001:0x0000": {
+    "description": "Plug Dimmer",
+    "label": "064394",
+    "manufacturer": "Schuko"
+  },
+  "0x0064:0x2001:0x0000": {
+    "description": "Duewi ZW BJ ES 1000 / Reitz 05431 / ZWave.me 05457 Single button wall switch",
+    "label": "ZW-ES-1000 / Reitz 05431",
+    "manufacturer": "Reitz-Group.de"
+  },
+  "0x0064:0x3001:0x0000": {
+    "description": "Schuko Plug Switch",
+    "label": "Duewi ZW-ZS-3500",
+    "manufacturer": "Reitz-Group.de"
+  },
+  "0x0064:0x3002:0x0000": {
+    "description": "Indoor/Outdoor Wall Plug Switch",
+    "label": "Duwi Z-Wave Plugin Switch",
+    "manufacturer": "Reitz-Group.de"
+  },
+  "0x0064:0x4001:0x0000": {
+    "description": "Duwi ZW ESJ 300 Blind Control",
+    "label": "ZW ESJ 300",
+    "manufacturer": "Reitz-Group.de"
+  },
+  "0x0064:0x5001:0x0000": {
+    "description": "D\u00fcwi Remote Control",
+    "label": "064459",
+    "manufacturer": "Reitz-Group.de"
+  },
+  "0x0064:0x5002:0x0000": {
+    "description": "Battery powered One paddle wall controller",
+    "label": "ZWWS",
+    "manufacturer": "Reitz-Group.de"
+  },
+  "0x0064:0x5003:0x0000": {
+    "description": "D\u00fcwi Repeater",
+    "label": "DUW_RPT",
+    "manufacturer": "Reitz-Group.de"
+  },
+  "0x0068:0x0000:0x000d": {
+    "description": "Door/Window Sensor with Magnet",
+    "label": "78008",
+    "manufacturer": "Good Way Technology Co., Ltd."
+  },
+  "0x0068:0x0000:0x0010": {
+    "description": "In wall Power Monitor Switch",
+    "label": "TD1311",
+    "manufacturer": "Good Way Technology Co., Ltd."
+  },
+  "0x0068:0x0002:0x0001": {
+    "description": "FG3200 Z-Wave\u00ae Home Gateway",
+    "label": "GATEWAY / FG3200",
+    "manufacturer": "Good Way Technology Co., Ltd."
+  },
+  "0x0068:0x0002:0x0002": {
+    "description": "FG2200 Z-Wave\u00ae Home Gateway",
+    "label": "GATEWAY / FG2200",
+    "manufacturer": "Good Way Technology Co., Ltd."
+  },
+  "0x0068:0x0003:0x0006": {
+    "description": "Smart Meter Switch",
+    "label": "TD13320",
+    "manufacturer": "Good Way Technology Co., Ltd."
+  },
+  "0x0068:0x0003:0x0009": {
+    "description": "Door/Window Sensor",
+    "label": "TS2001",
+    "manufacturer": "Good Way Technology Co., Ltd."
+  },
+  "0x0068:0x0003:0x000b": {
+    "description": "RGBW Dimmer Module",
+    "label": "36511",
+    "manufacturer": "Good Way Technology Co., Ltd."
+  },
+  "0x0068:0x0003:0x0015": {
+    "description": "In-wall switch",
+    "label": "TD13010",
+    "manufacturer": "Good Way Technology Co., Ltd."
+  },
+  "0x0068:0x0003:0x0016": {
+    "description": "Panic Button",
+    "label": "TR1B120Z1",
+    "manufacturer": "Good Way Technology Co., Ltd."
+  },
+  "0x006b:0x0010:0x0003": {
+    "description": "2-Button Z-Wave Remote Control",
+    "label": "200ZW-US-W",
+    "manufacturer": "Tricklestar Ltd. (former Empower Controls Ltd.)"
+  },
+  "0x006b:0x0028:0x0000": {
+    "description": "EU Z-Wave Interface Device + Mac Widget HAI",
+    "label": "20300ZW",
+    "manufacturer": "Tricklestar Ltd. (former Empower Controls Ltd.)"
+  },
+  "0x006f:0x0102:0x0001": {
+    "description": "Door/Window Contact",
+    "label": "HM-DW001",
+    "manufacturer": "Erone"
+  },
+  "0x006f:0x0103:0x0001": {
+    "description": "Lighting Module",
+    "label": "HM-LM001",
+    "manufacturer": "Erone"
+  },
+  "0x0071:0x0002:0x035d": {
+    "description": "Temperature Sensor",
+    "label": "E861C",
+    "manufacturer": "LS Control"
+  },
+  "0x0071:0x0004:0x035d": {
+    "description": "C Humidity Sensor",
+    "label": "ES861",
+    "manufacturer": "LS Control"
+  },
+  "0x0071:0x0005:0x035d": {
+    "description": "Setpoint sensor",
+    "label": "ES861C",
+    "manufacturer": "LS Control"
+  },
+  "0x0077:0x0001:0x0001": {
+    "description": "RAone SmartDimmer",
+    "label": "SmartDimmer",
+    "manufacturer": "INNOVUS"
+  },
+  "0x0077:0x0001:0x0002": {
+    "description": "RAone SmartPower",
+    "label": "SmartPower",
+    "manufacturer": "INNOVUS"
+  },
+  "0x0077:0x0002:0x0001": {
+    "description": "SmoothRemote",
+    "label": "SmoothRemote",
+    "manufacturer": "INNOVUS"
+  },
+  "0x0077:0x0010:0x0001": {
+    "description": "RAone SmartPower",
+    "label": "SmartPower",
+    "manufacturer": "INNOVUS"
+  },
+  "0x0077:0x0011:0x0001": {
+    "description": "RAone SmartDimmer",
+    "label": "SmartDimmer",
+    "manufacturer": "INNOVUS"
+  },
+  "0x007a:0x0001:0x0002": {
+    "description": "Radio Push-button CONNECT, 1 button",
+    "label": "5071xx",
+    "manufacturer": "Merten"
+  },
+  "0x007a:0x0001:0x0004": {
+    "description": "Battery Powered Wall Controller",
+    "label": "506219",
+    "manufacturer": "Merten"
+  },
+  "0x007a:0x0002:0x0001": {
+    "description": "Battery Powered Wall Controller MOVE",
+    "label": "508244",
+    "manufacturer": "Merten"
+  },
+  "0x007a:0x0002:0x0004": {
+    "description": "Schneider - Merten",
+    "label": "MTN5051-0000",
+    "manufacturer": "Merten"
+  },
+  "0x007a:0x0003:0x0004": {
+    "description": "Transmitter Flush-Mounted 4-Gang Switch",
+    "label": "506004",
+    "manufacturer": "Merten"
+  },
+  "0x007a:0x4002:0x0001": {
+    "description": "5044xx - Radio sensor cover for in-wall switch",
+    "label": "5044XX",
+    "manufacturer": "Merten"
+  },
+  "0x007a:0x4003:0x0001": {
+    "description": "5046xx - Radio sensor cover for in wall dimmer",
+    "label": "5046XX",
+    "manufacturer": "Merten"
+  },
+  "0x007a:0x4003:0x0002": {
+    "description": "Wall Dimmer Module - Flush Mounted",
+    "label": "507900",
+    "manufacturer": "Merten"
+  },
+  "0x007a:0x4004:0x0001": {
+    "description": "Roller shutter push-button",
+    "label": "50x5xx",
+    "manufacturer": "Merten"
+  },
+  "0x007a:0x4005:0x0001": {
+    "description": "Argus 220 Connect Movement Detector",
+    "label": "509519",
+    "manufacturer": "Merten"
+  },
+  "0x007a:0x8001:0x0001": {
+    "description": "Switch Plug",
+    "label": "508519",
+    "manufacturer": "Merten"
+  },
+  "0x007a:0x8001:0x8001": {
+    "description": "Switch Wall Insert 1 Gang",
+    "label": "507001",
+    "manufacturer": "Merten"
+  },
+  "0x007a:0x8001:0x8002": {
+    "description": "Flush-mounted switch",
+    "label": "507501 / 507502",
+    "manufacturer": "Merten"
+  },
+  "0x007a:0x8001:0x8003": {
+    "description": "Dual Pole Wall Switch",
+    "label": "507601",
+    "manufacturer": "Merten"
+  },
+  "0x007a:0x8001:0x8004": {
+    "description": "Flush-mounted switch",
+    "label": "507501 / 507502",
+    "manufacturer": "Merten"
+  },
+  "0x007a:0x8003:0x0001": {
+    "description": "CONNECT radio flush-mounted receiver, Roller shutter",
+    "label": "507801",
+    "manufacturer": "Merten"
+  },
+  "0x007e:0x0101:0x0206": {
+    "description": "Plugin Appliance Module",
+    "label": "ML LAS1000",
+    "manufacturer": "Monster Cable"
+  },
+  "0x007e:0x0200:0x014e": {
+    "description": "Scene Capable Plug-in Dimmer",
+    "label": "ML LD300",
+    "manufacturer": "Monster Cable"
+  },
+  "0x007e:0x0400:0x014e": {
+    "description": "Dimmer switch 600w incandescent",
+    "label": "IWD600S",
+    "manufacturer": "Monster Cable"
+  },
+  "0x007e:0x0401:0x0206": {
+    "description": "Dimmer switch 600w incandescent",
+    "label": "IWD600S",
+    "manufacturer": "Monster Cable"
+  },
+  "0x007f:0x0001:0x0001": {
+    "description": "Harmony Home Hub Extender",
+    "label": "N-R0009",
+    "manufacturer": "Logitech"
+  },
+  "0x0080:0x0001:0x0003": {
+    "description": "MaxTronic - Grating Unit",
+    "label": "Grating Unit",
+    "manufacturer": "MaxTronic"
+  },
+  "0x0080:0x0004:0x0001": {
+    "description": "CO2 sensor",
+    "label": "CO2 sensor",
+    "manufacturer": "DucoTronic"
+  },
+  "0x0081:0x0014:0x0001": {
+    "description": "C - Wall mounted ventilation unit",
+    "label": "AEROPA",
+    "manufacturer": "SIEGENIA-AUBI KG"
+  },
+  "0x0081:0x00a0:0x0001": {
+    "description": "Air quality sensor for indoor use",
+    "label": "SENSOAIR",
+    "manufacturer": "SIEGENIA-AUBI KG"
+  },
+  "0x0084:0x0013:0x0210": {
+    "description": "Wireless Water and Temperature Alarm",
+    "label": "WWA-02",
+    "manufacturer": "FortrezZ LLC"
+  },
+  "0x0084:0x0021:0x010a": {
+    "description": "Wireless Water and Temperature Alarm",
+    "label": "WWA-02",
+    "manufacturer": "FortrezZ LLC"
+  },
+  "0x0084:0x0023:0x0109": {
+    "description": "Wireless Water and Temperature Alarm",
+    "label": "WWA-02",
+    "manufacturer": "FortrezZ LLC"
+  },
+  "0x0084:0x0053:0x0216": {
+    "description": "Wireless Water and Temperature Alarm",
+    "label": "WWA-02",
+    "manufacturer": "FortrezZ LLC"
+  },
+  "0x0084:0x0061:0x010c": {
+    "description": "Wireless Water and Temperature Alarm",
+    "label": "WWA-02",
+    "manufacturer": "FortrezZ LLC"
+  },
+  "0x0084:0x0063:0x010c": {
+    "description": "Wireless Water and Temperature Alarm",
+    "label": "WWA-02",
+    "manufacturer": "FortrezZ LLC"
+  },
+  "0x0084:0x0073:0x020b": {
+    "description": "Flood & Temperature Sensor",
+    "label": "FTS05",
+    "manufacturer": "FortrezZ LLC"
+  },
+  "0x0084:0x0093:0x0114": {
+    "description": "Sump Pump Module",
+    "label": "SPM1",
+    "manufacturer": "FortrezZ LLC"
+  },
+  "0x0084:0x00a3:0x020a": {
+    "description": "FTS05P Flood and Temperature Sensor",
+    "label": "FTS05P",
+    "manufacturer": "FortrezZ LLC"
+  },
+  "0x0084:0x00a3:0x020e": {
+    "description": "FTS05P Flood and Temperature Sensor",
+    "label": "FTS05P",
+    "manufacturer": "FortrezZ LLC"
+  },
+  "0x0084:0x0213:0x020c": {
+    "description": "Wireless, Z-Wave Emergency Water Shut-off Valve",
+    "label": "WV-01_1002",
+    "manufacturer": "FortrezZ LLC"
+  },
+  "0x0084:0x0213:0x0214": {
+    "description": "Wireless Z-Wave Water Valve",
+    "label": "WV-01",
+    "manufacturer": "FortrezZ LLC"
+  },
+  "0x0084:0x0213:0x0215": {
+    "description": "Wireless Z-Wave Water Valve",
+    "label": "WV-01",
+    "manufacturer": "FortrezZ LLC"
+  },
+  "0x0084:0x0233:0xaa06": {
+    "description": "Wireless Z-Wave Water Valve",
+    "label": "WV-01",
+    "manufacturer": "FortrezZ LLC"
+  },
+  "0x0084:0x0243:0x0216": {
+    "description": "Wireless Z-Wave Water Valve",
+    "label": "WV-01",
+    "manufacturer": "FortrezZ LLC"
+  },
+  "0x0084:0x0243:0x0300": {
+    "description": "Wireless Z-Wave Water Valve",
+    "label": "WV-01",
+    "manufacturer": "FortrezZ LLC"
+  },
+  "0x0084:0x0253:0x0000": {
+    "description": "DynaQuip",
+    "label": "ZWACT",
+    "manufacturer": "FortrezZ LLC"
+  },
+  "0x0084:0x0311:0x010b": {
+    "description": "Siren and Strobe Alarm",
+    "label": "SSA1/SSA2",
+    "manufacturer": "FortrezZ LLC"
+  },
+  "0x0084:0x0313:0x0107": {
+    "description": "FortrezZ SSA1/SSA2 Siren & Strobe Alarm",
+    "label": "SSA1 - SSA2 01",
+    "manufacturer": "FortrezZ LLC"
+  },
+  "0x0084:0x0313:0x0108": {
+    "description": "Siren and Strobe Alarm",
+    "label": "SSA1/SSA2",
+    "manufacturer": "FortrezZ LLC"
+  },
+  "0x0084:0x0313:0x010b": {
+    "description": "Siren and Strobe Alarm",
+    "label": "SSA1/SSA2",
+    "manufacturer": "FortrezZ LLC"
+  },
+  "0x0084:0x0341:0x0205": {
+    "description": "Siren and Strobe Alarm",
+    "label": "SSA3",
+    "manufacturer": "FortrezZ LLC"
+  },
+  "0x0084:0x0343:0x0205": {
+    "description": "Siren & Strobe Alarm",
+    "label": "SSA3-P4",
+    "manufacturer": "FortrezZ LLC"
+  },
+  "0x0084:0x0451:0x010e": {
+    "description": "Digital or Analog Voltage input and/or Dry Contact Relay",
+    "label": "MIMOlite",
+    "manufacturer": "FortrezZ LLC"
+  },
+  "0x0084:0x0451:0x0110": {
+    "description": "Digital or Analog Voltage input and/or Dry Contact Relay",
+    "label": "MIMOlite",
+    "manufacturer": "FortrezZ LLC"
+  },
+  "0x0084:0x0453:0x010e": {
+    "description": "Digital or Analog Voltage input and/or Dry Contact Relay",
+    "label": "MIMOlite",
+    "manufacturer": "FortrezZ LLC"
+  },
+  "0x0084:0x0453:0x010f": {
+    "description": "Digital or Analog Voltage input and/or Dry Contact Relay",
+    "label": "MIMOlite",
+    "manufacturer": "FortrezZ LLC"
+  },
+  "0x0084:0x0453:0x0110": {
+    "description": "Digital or Analog Voltage input and/or Dry Contact Relay",
+    "label": "MIMOlite",
+    "manufacturer": "FortrezZ LLC"
+  },
+  "0x0084:0x0453:0x0111": {
+    "description": "Digital or Analog Voltage input and/or Dry Contact Relay",
+    "label": "MIMOlite",
+    "manufacturer": "FortrezZ LLC"
+  },
+  "0x0084:0x0463:0x0207": {
+    "description": "Dual Digital or Analog Voltage input and Dual Contact Relay",
+    "label": "MIMO2+",
+    "manufacturer": "FortrezZ LLC"
+  },
+  "0x0084:0x0463:0x0208": {
+    "description": "Dual Digital or Analog Voltage input and Dual Contact Relay",
+    "label": "MIMO2+",
+    "manufacturer": "FortrezZ LLC"
+  },
+  "0x0084:0x0473:0x0110": {
+    "description": "Flow Meter",
+    "label": "FMI",
+    "manufacturer": "FortrezZ LLC"
+  },
+  "0x0084:0x0513:0x0111": {
+    "description": "FortrezZ GDC1",
+    "label": "GDC1_FORTREZZ_1501",
+    "manufacturer": "FortrezZ LLC"
+  },
+  "0x0085:0x0001:0x0001": {
+    "description": "Z-Wave Controller",
+    "label": "ZWP10",
+    "manufacturer": "Fakro"
+  },
+  "0x0085:0x0002:0x0001": {
+    "description": "Chain Actuator",
+    "label": "ZWS12",
+    "manufacturer": "Fakro"
+  },
+  "0x0085:0x0002:0x0002": {
+    "description": "Roller Shutter Module",
+    "label": "ARZ",
+    "manufacturer": "Fakro"
+  },
+  "0x0085:0x0002:0x0003": {
+    "description": "Chain actuator 230VAC",
+    "label": "ZWS230",
+    "manufacturer": "Fakro"
+  },
+  "0x0085:0x0002:0x0010": {
+    "description": "Chain actuator - window opener (2019)",
+    "label": "ZWS12",
+    "manufacturer": "Fakro"
+  },
+  "0x0085:0x0002:0x0011": {
+    "description": "Chain actuator - window opener",
+    "label": "ZWS12n",
+    "manufacturer": "Fakro"
+  },
+  "0x0085:0x0002:0x0100": {
+    "description": "Chain actuator - window opener (2019)",
+    "label": "ZWS12",
+    "manufacturer": "Fakro"
+  },
+  "0x0085:0x0002:0x0111": {
+    "description": "Chain actuator - window opener",
+    "label": "ZWS12n",
+    "manufacturer": "Fakro"
+  },
+  "0x0085:0x0003:0x0001": {
+    "description": "Roller Shutter",
+    "label": "ARZ Z-Wave",
+    "manufacturer": "Fakro"
+  },
+  "0x0085:0x0003:0x0011": {
+    "description": "ARZ Z-Wave",
+    "label": "ARZ Z-WAV",
+    "manufacturer": "Fakro"
+  },
+  "0x0085:0x0003:0x0111": {
+    "description": "Roller Shutter Module",
+    "label": "ARZ 1.1",
+    "manufacturer": "Fakro"
+  },
+  "0x0085:0x0003:0x0112": {
+    "description": "Roller Shutter",
+    "label": "ARZ Solar",
+    "manufacturer": "Fakro"
+  },
+  "0x0085:0x0004:0x0011": {
+    "description": "Roller blind module",
+    "label": "ARF",
+    "manufacturer": "Fakro"
+  },
+  "0x0085:0x0005:0x0001": {
+    "description": "Awning Blinds Controller",
+    "label": "AMZ",
+    "manufacturer": "Fakro"
+  },
+  "0x0085:0x0005:0x0002": {
+    "description": "Solar Awning",
+    "label": "AMZ Solar",
+    "manufacturer": "Fakro"
+  },
+  "0x0085:0x0006:0x0002": {
+    "description": "Awning Blind",
+    "label": "VMZ Solar",
+    "manufacturer": "Fakro"
+  },
+  "0x0085:0x0006:0x0112": {
+    "description": "Awning Blind z-wave plus version",
+    "label": "VMZ Solar z-wave plus",
+    "manufacturer": "Fakro"
+  },
+  "0x0085:0x0007:0x0001": {
+    "description": "Weather Module",
+    "label": "ZWMP",
+    "manufacturer": "Fakro"
+  },
+  "0x0085:0x0011:0x0001": {
+    "description": "Chain Actuator",
+    "label": "ZWS12",
+    "manufacturer": "Fakro"
+  },
+  "0x0085:0x0022:0x0001": {
+    "description": "Roller Shutter FLiRS module",
+    "label": "ZWRS MODULE",
+    "manufacturer": "Fakro"
+  },
+  "0x0086:0x0000:0x0004": {
+    "description": "Goodway (Lamp Dimmer-USA) 2/5",
+    "label": "TD1010Z2",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0000:0x0005": {
+    "description": "GoodWay Z-Wave Power Switch",
+    "label": "TD1000Z2",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0000:0x0006": {
+    "description": "GoodWay Z-Wave Power Monitor",
+    "label": "TD1030Z1",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0001:0x0003": {
+    "description": "Minimote 4 button remote control",
+    "label": "DSA03XXX-ZW",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0001:0x0016": {
+    "description": "4 button keyfob",
+    "label": "DSA22",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0001:0x0026": {
+    "description": "Panic Button Key Fob",
+    "label": "DSA38-ZW",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0001:0x0058": {
+    "description": "4 button keyfob - Gen 5",
+    "label": "ZW088",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0001:0x005a": {
+    "description": "Z\u2010Stick Gen5 USB Controller",
+    "label": "ZW090",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0002:0x0001": {
+    "description": "Z-Stick S2 USB Controller",
+    "label": "DSA02203",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0002:0x0002": {
+    "description": "Water Sensor",
+    "label": "DSB45",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0002:0x0004": {
+    "description": "Door/Window sensor Gen2",
+    "label": "DSB29",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0002:0x0005": {
+    "description": "4 in One MultiSensor",
+    "label": "DSB05",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0002:0x0009": {
+    "description": "Home Energy Meter",
+    "label": "DSB09",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0002:0x001c": {
+    "description": "Home Energy Meter G2",
+    "label": "DSB28",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0002:0x001d": {
+    "description": "Door/Window sensor Gen2",
+    "label": "DSB29",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0002:0x002d": {
+    "description": "Water Sensor",
+    "label": "DSB45",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0002:0x0036": {
+    "description": "Recessed Door/Window Sensor",
+    "label": "DSB54",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0002:0x004a": {
+    "description": "4 in One MultiSensor (G5)",
+    "label": "ZW074",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0002:0x0059": {
+    "description": "Recessed Door Sensor Gen5",
+    "label": "ZW089",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0002:0x005f": {
+    "description": "Home Energy Meter - Gen 5",
+    "label": "ZW095",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0002:0x0061": {
+    "description": "Dry Contact Sensor",
+    "label": "ZW097",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0002:0x0064": {
+    "description": "MultiSensor 6",
+    "label": "ZW100",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0002:0x0070": {
+    "description": "Door/Window Sensor 6",
+    "label": "ZW112",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0002:0x0074": {
+    "description": "Aeotec Nano Switch",
+    "label": "ZW116",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0002:0x0078": {
+    "description": "Door/Window sensor Gen5",
+    "label": "ZW120",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0002:0x007a": {
+    "description": "Water Sensor 6",
+    "label": "ZW122",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0002:0x0081": {
+    "description": "Dual Wallmote",
+    "label": "ZW129",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0002:0x0082": {
+    "description": "WallMote Quad",
+    "label": "ZW130",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0003:0x0006": {
+    "description": "Smart Energy Switch",
+    "label": "DSC06",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0003:0x0008": {
+    "description": "Smart Energy Illuminator",
+    "label": "DSC08",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0003:0x000a": {
+    "description": "Heavy Duty Smart Switch",
+    "label": "DSC10",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0003:0x000b": {
+    "description": "Smart Strip",
+    "label": "DSC11",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0003:0x000c": {
+    "description": "Micro Smart Energy Switch",
+    "label": "DSC12",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0003:0x000d": {
+    "description": "Micro Smart Energy Illuminator",
+    "label": "DSC13",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0003:0x000e": {
+    "description": "Micro Motor Controller",
+    "label": "DSC14",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0003:0x0011": {
+    "description": "Micro Double Smart Switch",
+    "label": "DSC17",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0003:0x0012": {
+    "description": "Micro Smart Energy Switch G2",
+    "label": "DSC18",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0003:0x0013": {
+    "description": "Micro Smart Energy Illuminator G2",
+    "label": "DSC19",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0003:0x0018": {
+    "description": "Smart Energy Switch G2",
+    "label": "DSC24",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0003:0x0019": {
+    "description": "Smart Energy Illuminator G2",
+    "label": "DSC25",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0003:0x001a": {
+    "description": "Micro Switch G2",
+    "label": "DSC26103-ZW",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0003:0x001b": {
+    "description": "Micro Illuminator G2",
+    "label": "DSC27",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0003:0x0023": {
+    "description": "Micro Double Switch",
+    "label": "DSC35",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0003:0x003e": {
+    "description": "Aeon Labs Garage Door Controller Gen5",
+    "label": "ZW062",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0003:0x004b": {
+    "description": "Smart Energy Switch 3rd Edition",
+    "label": "ZW075",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0003:0x004e": {
+    "description": "Heavy Duty Switch",
+    "label": "ZW078",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0003:0x0060": {
+    "description": "Smart Switch 6",
+    "label": "ZW096",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0003:0x0062": {
+    "description": "LED Bulb",
+    "label": "ZW098",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0003:0x0063": {
+    "description": "Smart Dimmer 6",
+    "label": "ZW099",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0003:0x006f": {
+    "description": "Nano Dimmer",
+    "label": "ZW111",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0003:0x0074": {
+    "description": "Aeotec Nano Switch",
+    "label": "ZW116",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0003:0x0079": {
+    "description": "Aeotec LED Strip",
+    "label": "ZW121",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0003:0x0084": {
+    "description": "Dual Nano Switch with Energy Metering",
+    "label": "ZW132",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0003:0x008b": {
+    "description": "Nano Switch Gen5 (without meter)",
+    "label": "ZW139",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0003:0x008c": {
+    "description": "Dual Nano Switch",
+    "label": "ZW140",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0003:0x008d": {
+    "description": "ZW141",
+    "label": "Nano Shutter Controller",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0003:0xa10d": {
+    "description": "4 group single colour touch panel secondary controller",
+    "label": "ZV9001T4-DIM",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0004:0x0025": {
+    "description": "Range Extender",
+    "label": "DSD37",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0004:0x0038": {
+    "description": "Doorbell",
+    "label": "ZW056",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0004:0x0050": {
+    "description": "Outlet Plugable Siren",
+    "label": "DSD31",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0004:0x0075": {
+    "description": "Range Extender 6",
+    "label": "ZW117",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0006:0x0002": {
+    "description": "Minimote 4 button remote control",
+    "label": "DSA03XXX-ZW",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0019:0x0004": {
+    "description": "Range Extender",
+    "label": "DSD37",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0101:0x0058": {
+    "description": "4 button keyfob - Gen 5",
+    "label": "ZW088",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0101:0x005a": {
+    "description": "Z\u2010Stick Gen5 USB Controller",
+    "label": "ZW090",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0102:0x004a": {
+    "description": "4 in One MultiSensor (G5)",
+    "label": "ZW074",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0102:0x0059": {
+    "description": "Recessed Door Sensor Gen5",
+    "label": "ZW089",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0102:0x005f": {
+    "description": "Home Energy Meter - Gen 5",
+    "label": "ZW095",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0102:0x0061": {
+    "description": "Dry Contact Sensor",
+    "label": "ZW097",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0102:0x0064": {
+    "description": "MultiSensor 6",
+    "label": "ZW100",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0102:0x0070": {
+    "description": "Door/Window Sensor 6",
+    "label": "ZW112",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0102:0x0078": {
+    "description": "Door/Window sensor Gen5",
+    "label": "ZW120",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0102:0x007a": {
+    "description": "Water Sensor 6",
+    "label": "ZW122",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0102:0x0081": {
+    "description": "Dual Wallmote",
+    "label": "ZW129",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0102:0x0082": {
+    "description": "WallMote Quad",
+    "label": "ZW130",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0103:0x003e": {
+    "description": "Aeon Labs Garage Door Controller Gen5",
+    "label": "ZW062",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0103:0x004b": {
+    "description": "Smart Energy Switch 3rd Edition",
+    "label": "ZW075",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0103:0x004e": {
+    "description": "Heavy Duty Switch",
+    "label": "ZW078",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0103:0x0060": {
+    "description": "Smart Switch 6",
+    "label": "ZW096",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0103:0x0062": {
+    "description": "LED Bulb",
+    "label": "ZW098",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0103:0x0063": {
+    "description": "Smart Dimmer 6",
+    "label": "ZW099",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0103:0x006f": {
+    "description": "Nano Dimmer",
+    "label": "ZW111",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0103:0x0074": {
+    "description": "Aeotec Nano Switch",
+    "label": "ZW116",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0103:0x0079": {
+    "description": "Aeotec LED Strip",
+    "label": "ZW121",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0103:0x0084": {
+    "description": "Dual Nano Switch with Energy Metering",
+    "label": "ZW132",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0103:0x008b": {
+    "description": "Nano Switch Gen5 (without meter)",
+    "label": "ZW139",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0103:0x008c": {
+    "description": "Dual Nano Switch",
+    "label": "ZW140",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0103:0x008d": {
+    "description": "ZW141",
+    "label": "Nano Shutter Controller",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0104:0x0038": {
+    "description": "Doorbell",
+    "label": "ZW056",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0104:0x0050": {
+    "description": "Siren Gen5",
+    "label": "ZW080",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0104:0x0075": {
+    "description": "Range Extender 6",
+    "label": "ZW117",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x01f3:0x000f": {
+    "description": "Nano Dimmer",
+    "label": "ZW111",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x01f3:0x006f": {
+    "description": "Nano Dimmer",
+    "label": "ZW111",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0201:0x0058": {
+    "description": "4 button keyfob - Gen 5",
+    "label": "ZW088",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0201:0x005a": {
+    "description": "Z\u2010Stick Gen5 USB Controller",
+    "label": "ZW090",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0202:0x004a": {
+    "description": "4 in One MultiSensor (G5)",
+    "label": "ZW074",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0202:0x0059": {
+    "description": "Recessed Door Sensor Gen5",
+    "label": "ZW089",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0202:0x0061": {
+    "description": "Dry Contact Sensor",
+    "label": "ZW097",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0202:0x0064": {
+    "description": "MultiSensor 6",
+    "label": "ZW100",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0202:0x0070": {
+    "description": "Door/Window Sensor 6",
+    "label": "ZW112",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0202:0x0078": {
+    "description": "Door/Window sensor Gen5",
+    "label": "ZW120",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0202:0x007a": {
+    "description": "Water Sensor 6",
+    "label": "ZW122",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0202:0x0081": {
+    "description": "Dual Wallmote",
+    "label": "ZW129",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0202:0x0082": {
+    "description": "WallMote Quad",
+    "label": "ZW130",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0203:0x003e": {
+    "description": "Aeon Labs Garage Door Controller Gen5",
+    "label": "ZW062",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0203:0x004b": {
+    "description": "Smart Energy Switch 3rd Edition",
+    "label": "ZW075",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0203:0x004e": {
+    "description": "Heavy Duty Switch",
+    "label": "ZW078",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0203:0x0060": {
+    "description": "Smart Switch 6",
+    "label": "ZW096",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0203:0x0062": {
+    "description": "LED Bulb",
+    "label": "ZW098",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0203:0x0063": {
+    "description": "Smart Dimmer 6",
+    "label": "ZW099",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0203:0x006f": {
+    "description": "Nano Dimmer",
+    "label": "ZW111",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0203:0x0074": {
+    "description": "Aeotec Nano Switch",
+    "label": "ZW116",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0203:0x0079": {
+    "description": "Aeotec LED Strip",
+    "label": "ZW121",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0203:0x0084": {
+    "description": "Dual Nano Switch with Energy Metering",
+    "label": "ZW132",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0203:0x008b": {
+    "description": "Nano Switch Gen5 (without meter)",
+    "label": "ZW139",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0204:0x0038": {
+    "description": "Doorbell",
+    "label": "ZW056",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0204:0x0050": {
+    "description": "Siren Gen5",
+    "label": "ZW080",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0204:0x0075": {
+    "description": "Range Extender 6",
+    "label": "ZW117",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0300:0xa10b": {
+    "description": "4 group single colour touch panel secondary controller",
+    "label": "ZV9001T4-DIM",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0304:0x0038": {
+    "description": "Doorbell",
+    "label": "ZW056",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0904:0x0038": {
+    "description": "Doorbell",
+    "label": "ZW056",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x0a04:0x0038": {
+    "description": "Doorbell",
+    "label": "ZW056",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x1a02:0x0064": {
+    "description": "MultiSensor 6",
+    "label": "ZW100",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x1a03:0x004e": {
+    "description": "Heavy Duty Switch",
+    "label": "ZW078",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x1a04:0x0038": {
+    "description": "Doorbell",
+    "label": "ZW056",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x1d02:0x0070": {
+    "description": "Door/Window Sensor 6",
+    "label": "ZW112",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x1d03:0x0060": {
+    "description": "Smart Switch 6",
+    "label": "ZW096",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x1d03:0x0063": {
+    "description": "Smart Dimmer 6",
+    "label": "ZW099",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x1d04:0x0038": {
+    "description": "Doorbell",
+    "label": "ZW056",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0086:0x6015:0x020d": {
+    "description": "Door/Window Sensor 6",
+    "label": "ZW112",
+    "manufacturer": "AEON Labs"
+  },
+  "0x0089:0x0001:0x0101": {
+    "description": "Single relay switch",
+    "label": "ZSL301EU",
+    "manufacturer": "Team Precision PCL"
+  },
+  "0x0089:0x0002:0x0101": {
+    "description": "Easy Light Dimmer Link",
+    "label": "ZDL301",
+    "manufacturer": "Team Precision PCL"
+  },
+  "0x0089:0x0003:0x0001": {
+    "description": "Zuper Switch Remote Control 1 Gang",
+    "label": "ZUS101",
+    "manufacturer": "Team Precision PCL"
+  },
+  "0x0089:0x0003:0x0101": {
+    "description": "Zuper Switch Remote Control 2 Gang",
+    "label": "ZUS102",
+    "manufacturer": "Team Precision PCL"
+  },
+  "0x008a:0x0001:0x0100": {
+    "description": "Internet Gateway",
+    "label": "BENEXT / INTERNET GATEWAY",
+    "manufacturer": "BeNext"
+  },
+  "0x008a:0x0002:0x0100": {
+    "description": "Remote Display",
+    "label": "BENEXT MYDISPLAY",
+    "manufacturer": "BeNext"
+  },
+  "0x008a:0x0003:0x0100": {
+    "description": "Movement sensor with temperature and light sensor",
+    "label": "Molite",
+    "manufacturer": "BeNext"
+  },
+  "0x008a:0x0003:0x0101": {
+    "description": "Movement sensor with temperature and light sensor",
+    "label": "Molite",
+    "manufacturer": "BeNext"
+  },
+  "0x008a:0x0004:0x0100": {
+    "description": "Door Sensor",
+    "label": "DOOR SENSOR",
+    "manufacturer": "BeNext"
+  },
+  "0x008a:0x0004:0x0101": {
+    "description": "Door Sensor",
+    "label": "DOOR SENSOR",
+    "manufacturer": "BeNext"
+  },
+  "0x008a:0x0005:0x0100": {
+    "description": "Alarm Sound",
+    "label": "BENEXT / ALARM SOUN",
+    "manufacturer": "BeNext"
+  },
+  "0x008a:0x0005:0x0101": {
+    "description": "Alarm sound",
+    "label": "Alarm Sound",
+    "manufacturer": "BeNext"
+  },
+  "0x008a:0x0006:0x0100": {
+    "description": "Energy Switch +",
+    "label": "ENERGY SWITCH",
+    "manufacturer": "BeNext"
+  },
+  "0x008a:0x0007:0x0100": {
+    "description": "Tag Reader",
+    "label": "BENEXT / TAGREADER",
+    "manufacturer": "BeNext"
+  },
+  "0x008a:0x0007:0x0101": {
+    "description": "Tag Reader",
+    "label": "Tag Reader",
+    "manufacturer": "BeNext"
+  },
+  "0x008a:0x0007:0x0200": {
+    "description": "WTRFID Mini Keypad",
+    "label": "Tag Reader 500",
+    "manufacturer": "BeNext"
+  },
+  "0x008a:0x0008:0x0100": {
+    "description": "Power Switch EU",
+    "label": "PowerSwitch",
+    "manufacturer": "BeNext"
+  },
+  "0x008a:0x0008:0x0101": {
+    "description": "Power Switch EU",
+    "label": "PowerSwitch",
+    "manufacturer": "BeNext"
+  },
+  "0x008a:0x000d:0x0100": {
+    "description": "Built-in Dimmer",
+    "label": "builtInDimmer",
+    "manufacturer": "BeNext"
+  },
+  "0x008a:0x0018:0x0100": {
+    "description": "Plug-in Dimmer",
+    "label": "plugInDimmer",
+    "manufacturer": "BeNext"
+  },
+  "0x008a:0x0020:0x0001": {
+    "description": "Energy Switch +",
+    "label": "ENERGY SWITCH",
+    "manufacturer": "BeNext"
+  },
+  "0x008a:0x0021:0x0102": {
+    "description": "Thermostat for controlling the opentherm protocol",
+    "label": "Heating Control",
+    "manufacturer": "BeNext"
+  },
+  "0x008a:0x002f:0x0100": {
+    "description": "P1-dongle",
+    "label": "P1-dongle",
+    "manufacturer": "BeNext"
+  },
+  "0x008b:0x0003:0x006f": {
+    "description": "Nano Dimmer",
+    "label": "ZW111",
+    "manufacturer": "Trane Corporation"
+  },
+  "0x008b:0x0103:0x006f": {
+    "description": "Nano Dimmer",
+    "label": "ZW111",
+    "manufacturer": "Trane Corporation"
+  },
+  "0x008b:0x0203:0x006f": {
+    "description": "Nano Dimmer",
+    "label": "ZW111",
+    "manufacturer": "Trane Corporation"
+  },
+  "0x008b:0x4138:0x3234": {
+    "description": "Ingersoll Rand XL824 - American Standard Version",
+    "label": "ACONT824AS42D",
+    "manufacturer": "Trane Corporation"
+  },
+  "0x008b:0x4138:0x3235": {
+    "description": "Gold XV 824",
+    "label": "ACONT824AS52DB",
+    "manufacturer": "Trane Corporation"
+  },
+  "0x008b:0x4138:0x3530": {
+    "description": "XL850",
+    "label": "ACONT850AC52UA",
+    "manufacturer": "Trane Corporation"
+  },
+  "0x008b:0x4138:0x3535": {
+    "description": "Platinum XV 850",
+    "label": "ACONT850AC52UB",
+    "manufacturer": "Trane Corporation"
+  },
+  "0x008b:0x4141:0x3530": {
+    "description": "AccuLink II Platinum 1050",
+    "label": "AZON1050AC52ZA",
+    "manufacturer": "Trane Corporation"
+  },
+  "0x008b:0x4d53:0x4331": {
+    "description": "LE130",
+    "label": "LE130",
+    "manufacturer": "Schlage"
+  },
+  "0x008b:0x4d53:0x4332": {
+    "description": "Trane Z WAVE Mini Split Remote control - ANZ",
+    "label": "TRNZWR2",
+    "manufacturer": "Trane Corporation"
+  },
+  "0x008b:0x5438:0x3234": {
+    "description": "Ingersoll Rand XL824 Controller",
+    "label": "XL824",
+    "manufacturer": "Trane Corporation"
+  },
+  "0x008b:0x5438:0x3235": {
+    "description": "Ingersoll Rand XL824 Controller",
+    "label": "XL824",
+    "manufacturer": "Trane Corporation"
+  },
+  "0x008b:0x5438:0x325a": {
+    "description": "Ingersoll Rand XL824 Controller",
+    "label": "XL824",
+    "manufacturer": "Trane Corporation"
+  },
+  "0x008b:0x5438:0x3530": {
+    "description": "XL850",
+    "label": "XL850",
+    "manufacturer": "Trane Corporation"
+  },
+  "0x008b:0x5438:0x3535": {
+    "description": "XL850",
+    "label": "XL850",
+    "manufacturer": "Trane Corporation"
+  },
+  "0x008b:0x5441:0x3530": {
+    "description": "XL1050",
+    "label": "TZON1050AC52ZA",
+    "manufacturer": "Trane Corporation"
+  },
+  "0x008b:0x5452:0x5431": {
+    "description": "Trane Z-Wave Programmable Thermostat",
+    "label": "T400",
+    "manufacturer": "Trane Corporation"
+  },
+  "0x008b:0x5452:0x5432": {
+    "description": "Trane TZEMT400B - Home Energy Management Thermostat",
+    "label": "TRANE T400",
+    "manufacturer": "Trane Corporation"
+  },
+  "0x008b:0x5452:0x5433": {
+    "description": "Trane Z-Wave Programmable Thermostat",
+    "label": "T400",
+    "manufacturer": "Trane Corporation"
+  },
+  "0x008b:0x5452:0x5434": {
+    "description": "Z-Wave Thermostat",
+    "label": "T500",
+    "manufacturer": "Trane Corporation"
+  },
+  "0x008b:0x5452:0x5435": {
+    "description": "Z-Wave Thermostat",
+    "label": "T500",
+    "manufacturer": "Trane Corporation"
+  },
+  "0x008b:0x5452:0x5436": {
+    "description": "Trane Z-Wave Programmable Thermostat",
+    "label": "T400",
+    "manufacturer": "Trane Corporation"
+  },
+  "0x008b:0x5452:0x5437": {
+    "description": "Z-Wave Thermostat",
+    "label": "T500",
+    "manufacturer": "Trane Corporation"
+  },
+  "0x008b:0x5452:0x5439": {
+    "description": "Touchscreen Comfort Control Thermostat",
+    "label": "XL624",
+    "manufacturer": "Trane Corporation"
+  },
+  "0x008b:0x5452:0x5442": {
+    "description": "Touchscreen Comfort Control Thermostat",
+    "label": "Trane XR524",
+    "manufacturer": "Trane Corporation"
+  },
+  "0x008b:0x5452:0x5443": {
+    "description": "Touchscreen Comfort Control Thermostat",
+    "label": "XL624",
+    "manufacturer": "Trane Corporation"
+  },
+  "0x008c:0x0001:0x0001": {
+    "description": "Vera Home Gateway",
+    "label": "VERA 2",
+    "manufacturer": "Vera Control"
+  },
+  "0x008c:0x0001:0x0022": {
+    "description": "Homelive Base",
+    "label": "NA930",
+    "manufacturer": "Vera Control"
+  },
+  "0x008c:0x0001:0x0023": {
+    "description": "Smart Home Controller",
+    "label": "VERAEDGE",
+    "manufacturer": "Vera Control"
+  },
+  "0x008c:0x0001:0x0024": {
+    "description": "Multiple RF Home Gateway",
+    "label": "VERAPLUS",
+    "manufacturer": "Vera Control"
+  },
+  "0x008c:0x0001:0x0025": {
+    "description": "Advanced Smart Home Security Controller",
+    "label": "VERASECURE",
+    "manufacturer": "Vera Control"
+  },
+  "0x008c:0x0001:0x003d": {
+    "description": "CyberTAN",
+    "label": "ZE250",
+    "manufacturer": "Vera Control"
+  },
+  "0x008c:0x0002:0x0001": {
+    "description": "MIOS VeraLite",
+    "label": "VERALITE",
+    "manufacturer": "Vera Control"
+  },
+  "0x008c:0x0002:0x0002": {
+    "description": "MIOS VeraLite",
+    "label": "VERALITE",
+    "manufacturer": "Vera Control"
+  },
+  "0x008c:0x0002:0x0032": {
+    "description": "Bosch Controller",
+    "label": "G100",
+    "manufacturer": "Vera Control"
+  },
+  "0x008c:0x0003:0x0033": {
+    "description": "Homelive Base",
+    "label": "NA930FR",
+    "manufacturer": "Vera Control"
+  },
+  "0x008c:0x0014:0x0023": {
+    "description": "URC Z-Wave Gateway",
+    "label": "TRF-ZW2",
+    "manufacturer": "Vera Control"
+  },
+  "0x008c:0x0037:0x0023": {
+    "description": "Standard Controller",
+    "label": "NHUB100",
+    "manufacturer": "Vera Control"
+  },
+  "0x008c:0x0037:0x0024": {
+    "description": "Premium Controller",
+    "label": "NHUB200",
+    "manufacturer": "Vera Control"
+  },
+  "0x0090:0x0001:0x0001": {
+    "description": "Smart Code with Home Connect Technology",
+    "label": "910",
+    "manufacturer": "Kwikset"
+  },
+  "0x0090:0x0001:0x0236": {
+    "description": "Smart Code with Home Connect Technology",
+    "label": "910",
+    "manufacturer": "Kwikset"
+  },
+  "0x0090:0x0001:0x0336": {
+    "description": "Door Lock",
+    "label": "912",
+    "manufacturer": "Kwikset"
+  },
+  "0x0090:0x0001:0x0436": {
+    "description": "Door Lock",
+    "label": "914",
+    "manufacturer": "Kwikset"
+  },
+  "0x0090:0x0001:0x0642": {
+    "description": "Door Lock",
+    "label": "916",
+    "manufacturer": "Kwikset"
+  },
+  "0x0090:0x0003:0x0236": {
+    "description": "Door Lock",
+    "label": "912",
+    "manufacturer": "Kwikset"
+  },
+  "0x0090:0x0003:0x0238": {
+    "description": "Smart Code with Home Connect Technology",
+    "label": "910",
+    "manufacturer": "Kwikset"
+  },
+  "0x0090:0x0003:0x0339": {
+    "description": "Door Lock",
+    "label": "912",
+    "manufacturer": "Kwikset"
+  },
+  "0x0090:0x0003:0x0440": {
+    "description": "Door Lock",
+    "label": "914",
+    "manufacturer": "Kwikset"
+  },
+  "0x0090:0x0003:0x0446": {
+    "description": "Convert Smart Lock",
+    "label": "914C",
+    "manufacturer": "Kwikset"
+  },
+  "0x0090:0x0003:0x0541": {
+    "description": "Touchpad Electronic Deadbolt",
+    "label": "SmartCode 888",
+    "manufacturer": "Kwikset"
+  },
+  "0x0090:0x0003:0x0642": {
+    "description": "Door Lock",
+    "label": "916",
+    "manufacturer": "Kwikset"
+  },
+  "0x0090:0x0003:0x0742": {
+    "description": "Touchscreen Electronic Deadbolt",
+    "label": "Obsidian 954",
+    "manufacturer": "Kwikset"
+  },
+  "0x0090:0x0003:0x4006": {
+    "description": "Door Lock",
+    "label": "914",
+    "manufacturer": "Kwikset"
+  },
+  "0x0090:0x0006:0x0440": {
+    "description": "SmartCode 10 Touchpad Electronic Deadbolt",
+    "label": "GED1800",
+    "manufacturer": "Weiser"
+  },
+  "0x0090:0x0006:0x0742": {
+    "description": "Obsidian Touchscreen Electronic Deadbolt",
+    "label": "GED2350",
+    "manufacturer": "Weiser"
+  },
+  "0x0090:0x0009:0x0238": {
+    "description": "Boulder AC Z-Wave Deadbolt",
+    "label": "8252",
+    "manufacturer": "Baldwin"
+  },
+  "0x0090:0x0009:0x0642": {
+    "description": "Minneapolis 10 Touchscreen Electronic Deadbolt",
+    "label": "8225",
+    "manufacturer": "Baldwin"
+  },
+  "0x0090:0x0811:0x03a8": {
+    "description": "10 Button Z-Wave Plus v2 Deadbolt",
+    "label": "892",
+    "manufacturer": "Spectrum Brands"
+  },
+  "0x0091:0x0001:0x0091": {
+    "description": "Electricity meters",
+    "label": "electricity_meter",
+    "manufacturer": "Kamstrup A/S"
+  },
+  "0x0092:0x0102:0x0002": {
+    "description": "Martin Renz GmbH - UPz- Empf\u0084nger",
+    "label": "UPz- Empfnger",
+    "manufacturer": "Martin Renz GmbH"
+  },
+  "0x0094:0x0001:0x0001": {
+    "description": "Alarm.com Z-Wave Snap Device D v1",
+    "label": "ADC-ZW-EV",
+    "manufacturer": "Alarm.com"
+  },
+  "0x0094:0x0001:0x0101": {
+    "description": "Alarm.com Interlogix Simon XT/i Radio Module",
+    "label": "ADC-200H-EV",
+    "manufacturer": "Alarm.com"
+  },
+  "0x0094:0x0001:0x0102": {
+    "description": "Alarm.com Hub",
+    "label": "ADC-NK-100T",
+    "manufacturer": "Alarm.com"
+  },
+  "0x0094:0x0004:0x0104": {
+    "description": "Wireless Alarm System with Integrated Home Automation",
+    "label": "WS900-29",
+    "manufacturer": "Alarm.com"
+  },
+  "0x0094:0x000a:0x010a": {
+    "description": "Alarm.com Module for DSC Panels",
+    "label": "ADC-620T",
+    "manufacturer": "Alarm.com"
+  },
+  "0x0094:0x000b:0x010b": {
+    "description": "ADTZWM - Wi-Fi\u00ae and Z-Wave\u00ae Module for Command",
+    "label": "ADTZWM FOR COMMAN",
+    "manufacturer": "Alarm.com"
+  },
+  "0x0094:0x000e:0x010e": {
+    "description": "Alarm.com Rev4.7 Radio Module",
+    "label": "ADC-470L",
+    "manufacturer": "Alarm.com"
+  },
+  "0x0094:0x0012:0x0112": {
+    "description": "xDSL / GFAST GW",
+    "label": "HT-138S",
+    "manufacturer": "Alarm.com"
+  },
+  "0x0095:0x0001:0x0001": {
+    "description": "QEES Ring EU",
+    "label": "QEES MYKEY",
+    "manufacturer": "Qees"
+  },
+  "0x0095:0x0002:0x0001": {
+    "description": "Wall mountable mini 4 button remote",
+    "label": "Wall",
+    "manufacturer": "Qees"
+  },
+  "0x0095:0x0003:0x0000": {
+    "description": "QEES Power EU",
+    "label": "QEES RETO",
+    "manufacturer": "Qees"
+  },
+  "0x0095:0x3101:0x0001": {
+    "description": "QEES Dimmer US",
+    "label": "UNI",
+    "manufacturer": "Qees"
+  },
+  "0x0095:0x3103:0x0001": {
+    "description": "Plug-in Socket Dimmer",
+    "label": "P313A",
+    "manufacturer": "Qees"
+  },
+  "0x0095:0x3201:0x0001": {
+    "description": "QEES P321I MyKey Remote EU",
+    "label": "321-IQ(WB)-A1",
+    "manufacturer": "Qees"
+  },
+  "0x0095:0x3201:0x0010": {
+    "description": "QEES MyKey Remote US",
+    "label": "P321I",
+    "manufacturer": "Qees"
+  },
+  "0x0096:0x0001:0x0001": {
+    "description": "Electrical Meter",
+    "label": "NQ-9021",
+    "manufacturer": "NorthQ"
+  },
+  "0x0096:0x0001:0x0002": {
+    "description": "Electrical Meter",
+    "label": "NQ-9022",
+    "manufacturer": "NorthQ"
+  },
+  "0x0096:0x000a:0x0000": {
+    "description": "Q-Plug (NQ-9300-EU)",
+    "label": "NQ-9300-EU",
+    "manufacturer": "NorthQ"
+  },
+  "0x0096:0x0010:0x0001": {
+    "description": "NorthQ Gas Meter",
+    "label": "NQ-9121",
+    "manufacturer": "NorthQ"
+  },
+  "0x0097:0x0023:0x0045": {
+    "description": "iShutter",
+    "label": "ISHUTTER",
+    "manufacturer": "Wintop"
+  },
+  "0x0097:0x0024:0x0045": {
+    "description": "iShutter",
+    "label": "ISHUTTER",
+    "manufacturer": "Wintop"
+  },
+  "0x0097:0x0024:0x0051": {
+    "description": "iShutter",
+    "label": "ISHUTTER",
+    "manufacturer": "Wintop"
+  },
+  "0x0097:0x0024:0x0055": {
+    "description": "Blind controller",
+    "label": "DHS-WIN-BLW-DHS",
+    "manufacturer": "Wintop"
+  },
+  "0x0097:0x1121:0x5501": {
+    "description": "In Wall Switch",
+    "label": "Digital Home Systems",
+    "manufacturer": "Wintop"
+  },
+  "0x0097:0x1122:0x5501": {
+    "description": "Dual In-wall Switch",
+    "label": "iModuleDouble",
+    "manufacturer": "Wintop"
+  },
+  "0x0097:0x1180:0x4500": {
+    "description": "Wintop iSensor",
+    "label": "80",
+    "manufacturer": "Wintop"
+  },
+  "0x0097:0x1180:0x5501": {
+    "description": "Multi-sensor",
+    "label": "Multisensor",
+    "manufacturer": "Wintop"
+  },
+  "0x0097:0x1182:0x4500": {
+    "description": "Wintop iDoorSensor",
+    "label": "82",
+    "manufacturer": "Wintop"
+  },
+  "0x0097:0x1200:0x5502": {
+    "description": "DHS Z-Wave Micro Dimmer",
+    "label": "DHSZWDMIW01",
+    "manufacturer": "Wintop"
+  },
+  "0x0097:0x4501:0x6131": {
+    "description": "Keypad with alarm activation rfid tag",
+    "label": "MINI KEYPAD RFID",
+    "manufacturer": "Wintop"
+  },
+  "0x0097:0x6123:0x4500": {
+    "description": "Wintop iGate",
+    "label": "IGAT",
+    "manufacturer": "Wintop"
+  },
+  "0x0097:0x6131:0x4101": {
+    "description": "Keypad with alarm activation rfid tag",
+    "label": "MINI KEYPAD RFID",
+    "manufacturer": "Wintop"
+  },
+  "0x0097:0x6131:0x4501": {
+    "description": "Keypad with alarm activation rfid tag",
+    "label": "MINI KEYPAD RFID",
+    "manufacturer": "Wintop"
+  },
+  "0x0097:0x6131:0x5501": {
+    "description": "Keypad with alarm activation rfid tag",
+    "label": "MINI KEYPAD RFID",
+    "manufacturer": "Wintop"
+  },
+  "0x0097:0x6941:0x5501": {
+    "description": "Appliance Module",
+    "label": "LE120",
+    "manufacturer": "Wintop"
+  },
+  "0x0097:0x6942:0x4503": {
+    "description": "Wall Plug with dimming function",
+    "label": "iPlugDim",
+    "manufacturer": "Wintop"
+  },
+  "0x0097:0x6942:0x5503": {
+    "description": "DHS Z-Wave Plug-In Dimmer",
+    "label": "DHSZWDMPL01",
+    "manufacturer": "Wintop"
+  },
+  "0x0097:0x6943:0x4500": {
+    "description": "Wintop iPlugEnergy",
+    "label": "IPLUGENERGY",
+    "manufacturer": "Wintop"
+  },
+  "0x0097:0x6943:0x4501": {
+    "description": "Wall Plug",
+    "label": "EasyPlug",
+    "manufacturer": "Wintop"
+  },
+  "0x0097:0x6943:0x5501": {
+    "description": "PlugIn Switch with power monitoring",
+    "label": "PlugInSwitch",
+    "manufacturer": "Wintop"
+  },
+  "0x0098:0x0000:0x0000": {
+    "description": "Z-Wave Thermostat",
+    "label": "CT30",
+    "manufacturer": "Radio Thermostat Company of America (RTC)"
+  },
+  "0x0098:0x0001:0x001e": {
+    "description": "Z-Wave Thermostat",
+    "label": "CT30",
+    "manufacturer": "Radio Thermostat Company of America (RTC)"
+  },
+  "0x0098:0x0001:0x00f0": {
+    "description": "Z-Wave Thermostat",
+    "label": "CT30",
+    "manufacturer": "Radio Thermostat Company of America (RTC)"
+  },
+  "0x0098:0x0001:0x00ff": {
+    "description": "Z-Wave Thermostat",
+    "label": "CT30",
+    "manufacturer": "Radio Thermostat Company of America (RTC)"
+  },
+  "0x0098:0x0002:0x0100": {
+    "description": "Z-Wave Thermostat",
+    "label": "CT32",
+    "manufacturer": "Radio Thermostat Company of America (RTC)"
+  },
+  "0x0098:0x1e10:0x0158": {
+    "description": "Z-Wave Thermostat",
+    "label": "CT30",
+    "manufacturer": "Radio Thermostat Company of America (RTC)"
+  },
+  "0x0098:0x1e10:0x015c": {
+    "description": "Z-Wave Thermostat",
+    "label": "CT30",
+    "manufacturer": "Radio Thermostat Company of America (RTC)"
+  },
+  "0x0098:0x1e12:0x015c": {
+    "description": "Z-Wave Thermostat",
+    "label": "CT30",
+    "manufacturer": "Radio Thermostat Company of America (RTC)"
+  },
+  "0x0098:0x1e12:0x015e": {
+    "description": "Z-Wave Thermostat",
+    "label": "CT30",
+    "manufacturer": "Radio Thermostat Company of America (RTC)"
+  },
+  "0x0098:0x2002:0x0100": {
+    "description": "Z-Wave Thermostat",
+    "label": "CT32",
+    "manufacturer": "Radio Thermostat Company of America (RTC)"
+  },
+  "0x0098:0x2002:0x0102": {
+    "description": "Z-Wave Thermostat",
+    "label": "CT32",
+    "manufacturer": "Radio Thermostat Company of America (RTC)"
+  },
+  "0x0098:0x3200:0x015e": {
+    "description": "Z-Wave Thermostat",
+    "label": "CT30",
+    "manufacturer": "Radio Thermostat Company of America (RTC)"
+  },
+  "0x0098:0x5002:0x0100": {
+    "description": "Z-Wave Thermostat",
+    "label": "CT80",
+    "manufacturer": "Radio Thermostat Company of America (RTC)"
+  },
+  "0x0098:0x5002:0x0108": {
+    "description": "Z-Wave Thermostat",
+    "label": "CT80",
+    "manufacturer": "Radio Thermostat Company of America (RTC)"
+  },
+  "0x0098:0x5003:0x0109": {
+    "description": "Z-Wave Thermostat",
+    "label": "CT80",
+    "manufacturer": "Radio Thermostat Company of America (RTC)"
+  },
+  "0x0098:0x6401:0x0015": {
+    "description": "Z-Wave Thermostat",
+    "label": "CT100",
+    "manufacturer": "Radio Thermostat Company of America (RTC)"
+  },
+  "0x0098:0x6401:0x0103": {
+    "description": "Z-Wave Thermostat",
+    "label": "CT100",
+    "manufacturer": "Radio Thermostat Company of America (RTC)"
+  },
+  "0x0098:0x6401:0x0105": {
+    "description": "Z-Wave Thermostat",
+    "label": "CT100",
+    "manufacturer": "Radio Thermostat Company of America (RTC)"
+  },
+  "0x0098:0x6401:0x0106": {
+    "description": "Z-Wave Thermostat",
+    "label": "CT100",
+    "manufacturer": "Radio Thermostat Company of America (RTC)"
+  },
+  "0x0098:0x6401:0x0107": {
+    "description": "Z-Wave Thermostat",
+    "label": "CT100",
+    "manufacturer": "Radio Thermostat Company of America (RTC)"
+  },
+  "0x0098:0x6401:0x01fd": {
+    "description": "Z-Wave Thermostat",
+    "label": "CT100",
+    "manufacturer": "Radio Thermostat Company of America (RTC)"
+  },
+  "0x0098:0x6402:0x0001": {
+    "description": "Z-Wave Thermostat",
+    "label": "CT100",
+    "manufacturer": "Radio Thermostat Company of America (RTC)"
+  },
+  "0x0098:0x6402:0x0100": {
+    "description": "Z-Wave Thermostat",
+    "label": "CT100 Plus",
+    "manufacturer": "Radio Thermostat Company of America (RTC)"
+  },
+  "0x0098:0x6501:0x0000": {
+    "description": "Z-Wave Thermostat",
+    "label": "CT101",
+    "manufacturer": "Radio Thermostat Company of America (RTC)"
+  },
+  "0x0098:0x6501:0x000b": {
+    "description": "Z-Wave Thermostat",
+    "label": "CT101",
+    "manufacturer": "Radio Thermostat Company of America (RTC)"
+  },
+  "0x0098:0x6501:0x000c": {
+    "description": "Z-Wave Thermostat",
+    "label": "CT101",
+    "manufacturer": "Radio Thermostat Company of America (RTC)"
+  },
+  "0x0098:0x6501:0x000d": {
+    "description": "Z-Wave Thermostat",
+    "label": "CT101",
+    "manufacturer": "Radio Thermostat Company of America (RTC)"
+  },
+  "0x0098:0x6e01:0x0000": {
+    "description": "Thermostat",
+    "label": "CT110",
+    "manufacturer": "Radio Thermostat Company of America (RTC)"
+  },
+  "0x0098:0x6e01:0x0100": {
+    "description": "Thermostat",
+    "label": "CT110",
+    "manufacturer": "Radio Thermostat Company of America (RTC)"
+  },
+  "0x0098:0x6e02:0x0101": {
+    "description": "Thermostat",
+    "label": "CT110",
+    "manufacturer": "Radio Thermostat Company of America (RTC)"
+  },
+  "0x0098:0xc801:0x000c": {
+    "description": "Vivint Element Thermostat w/ other sensors",
+    "label": "CT200",
+    "manufacturer": "Radio Thermostat Company of America (RTC)"
+  },
+  "0x0098:0xc801:0x001d": {
+    "description": "Vivint Element Thermostat w/ other sensors",
+    "label": "CT200",
+    "manufacturer": "Radio Thermostat Company of America (RTC)"
+  },
+  "0x0098:0xc801:0x0022": {
+    "description": "Vivint Element Thermostat w/ other sensors",
+    "label": "CT200X",
+    "manufacturer": "Radio Thermostat Company of America (RTC)"
+  },
+  "0x0099:0x0001:0x0002": {
+    "description": "OneGateway",
+    "label": "GS1110-1-GR",
+    "manufacturer": "GreenWave Reality Inc."
+  },
+  "0x0099:0x0001:0xa001": {
+    "description": "AXON\u2122 Home Router",
+    "label": "GWS-HR-001",
+    "manufacturer": "GreenWave Reality Inc."
+  },
+  "0x0099:0x0002:0x0002": {
+    "description": "Single-socket PowerNode",
+    "label": "GWPN1",
+    "manufacturer": "GreenWave Reality Inc."
+  },
+  "0x0099:0x0003:0x0003": {
+    "description": "Multi-socket PowerNode (5-plug)",
+    "label": "NP210",
+    "manufacturer": "GreenWave Reality Inc."
+  },
+  "0x0099:0x0003:0x0004": {
+    "description": "Multi-socket PowerNode (6-plug)",
+    "label": "NP240 / NP242",
+    "manufacturer": "GreenWave Reality Inc."
+  },
+  "0x0099:0x0003:0x0006": {
+    "description": "Multi-socket PowerNode (6-plug)",
+    "label": "NP240 / NP242",
+    "manufacturer": "GreenWave Reality Inc."
+  },
+  "0x0099:0x0006:0x0001": {
+    "description": "GreenWave Reality In Home Display",
+    "label": "DE220",
+    "manufacturer": "GreenWave Reality Inc."
+  },
+  "0x009b:0x1000:0x1001": {
+    "description": "Go!Control Wireless Security System",
+    "label": "2GIG CONTROL 1 345 / CONTROL 2 345",
+    "manufacturer": "2gig Technologies Inc."
+  },
+  "0x009b:0x4350:0x3330": {
+    "description": "2GIG GC3",
+    "label": "2GIG-GC3-345",
+    "manufacturer": "2gig Technologies Inc."
+  },
+  "0x009b:0x5354:0x5a31": {
+    "description": "2GIG Z-Wave Plus 700-series Programmable Thermostat",
+    "label": "2GIG-STZ",
+    "manufacturer": "2gig Technologies Inc."
+  },
+  "0x009e:0x0001:0x0001": {
+    "description": "AI Ring US (QEES)",
+    "label": "0201002 V1.13",
+    "manufacturer": "Adventure Interactive"
+  },
+  "0x009e:0x0002:0x0001": {
+    "description": "AI Switch US (QEES)",
+    "label": "AI SWITCH",
+    "manufacturer": "Adventure Interactive"
+  },
+  "0x0100:0x0001:0x0020": {
+    "description": "Insignia LED TV 42",
+    "label": "NS-42E859A11",
+    "manufacturer": "Insignia"
+  },
+  "0x0102:0x0001:0x0001": {
+    "description": "Teleprtall Remote (SMK remote)",
+    "label": "REMOT",
+    "manufacturer": "SMK Manufacturing Inc."
+  },
+  "0x0103:0x0001:0x0002": {
+    "description": "Plug Actuator",
+    "label": "SES FS-ZW",
+    "manufacturer": "Diehl AKO"
+  },
+  "0x0103:0x0002:0x0002": {
+    "description": "DiehlControls Dimmer Actuator",
+    "label": "766366",
+    "manufacturer": "Diehl AKO"
+  },
+  "0x0106:0x0001:0x0001": {
+    "description": "iControl iHub",
+    "label": "IHU",
+    "manufacturer": "iControl"
+  },
+  "0x0106:0x0002:0x0001": {
+    "description": "iControl MiFi Secure",
+    "label": "649496 02012 5",
+    "manufacturer": "iControl"
+  },
+  "0x0106:0x0003:0x0002": {
+    "description": "Piper NV Security camera / sensor",
+    "label": "PIPER NV",
+    "manufacturer": "iControl"
+  },
+  "0x0106:0x0004:0x0001": {
+    "description": "iControl One Link controller",
+    "label": "CH-1000",
+    "manufacturer": "iControl"
+  },
+  "0x0107:0x0403:0x1000": {
+    "description": "FIBARO Single Relais Switch",
+    "label": "FIBEFGS-213",
+    "manufacturer": "MegaChips"
+  },
+  "0x0108:0x0002:0x000d": {
+    "description": "Battery Motion Sensor",
+    "label": "DCH-Z120",
+    "manufacturer": "D-Link"
+  },
+  "0x0108:0x0002:0x000e": {
+    "description": "Door & Window Sensor",
+    "label": "DCH-Z110",
+    "manufacturer": "D-Link"
+  },
+  "0x0108:0x0002:0x001e": {
+    "description": "Smoke Detector",
+    "label": "DCH-Z310",
+    "manufacturer": "D-Link"
+  },
+  "0x0108:0x0002:0x0034": {
+    "description": "mydlink\u2122 Door/Window Sensor",
+    "label": "DCH-Z112",
+    "manufacturer": "D-Link"
+  },
+  "0x0108:0x0004:0x000a": {
+    "description": "Siren",
+    "label": "DCH-Z510",
+    "manufacturer": "D-Link"
+  },
+  "0x0108:0x0020:0x0001": {
+    "description": "mydlink\u00ae Connected Home Hub",
+    "label": "DCH-G020",
+    "manufacturer": "D-Link"
+  },
+  "0x0108:0x0022:0x0003": {
+    "description": "D-Link mydlink Connected Home Hub",
+    "label": "DCH-G022",
+    "manufacturer": "D-Link"
+  },
+  "0x0108:0x2801:0x0001": {
+    "description": "Staples Connect Hub powered by D-Link",
+    "label": "DCH-G021",
+    "manufacturer": "D-Link"
+  },
+  "0x0109:0x0000:0x0000": {
+    "description": "USB Dongle",
+    "label": "ZU1401",
+    "manufacturer": "Vision Security"
+  },
+  "0x0109:0x0001:0x0000": {
+    "description": "Push Button Deadbolt",
+    "label": "YRD210",
+    "manufacturer": "Yale"
+  },
+  "0x0109:0x0002:0x0000": {
+    "description": "Push Button Deadbolt",
+    "label": "YRD210",
+    "manufacturer": "Yale"
+  },
+  "0x0109:0x0002:0xffff": {
+    "description": "Yale Real Living Touchscreen Lever Lock",
+    "label": "YALE/YRL/220",
+    "manufacturer": "Vision Security"
+  },
+  "0x0109:0x0003:0x0000": {
+    "description": "Push Button Deadbolt",
+    "label": "YRD210",
+    "manufacturer": "Yale"
+  },
+  "0x0109:0x0004:0x0000": {
+    "description": "Push Button Deadbolt",
+    "label": "YRD210",
+    "manufacturer": "Yale"
+  },
+  "0x0109:0x1001:0x0101": {
+    "description": "USB Dongle",
+    "label": "ZU1401",
+    "manufacturer": "Vision Security"
+  },
+  "0x0109:0x1001:0x0102": {
+    "description": "USB Dongle",
+    "label": "ZU1401",
+    "manufacturer": "Vision Security"
+  },
+  "0x0109:0x1002:0x0202": {
+    "description": "Keyfob",
+    "label": "ZT1101",
+    "manufacturer": "Vision Security"
+  },
+  "0x0109:0x1004:0x0402": {
+    "description": "Wall Remote",
+    "label": "ZT1141EU-5",
+    "manufacturer": "Vision Security"
+  },
+  "0x0109:0x1005:0x0501": {
+    "description": "Z-Wave Gateway",
+    "label": "ZA1011EU-5",
+    "manufacturer": "Vision Security"
+  },
+  "0x0109:0x2001:0x0101": {
+    "description": "Door Window Sensor",
+    "label": "ZD2102",
+    "manufacturer": "Vision Security"
+  },
+  "0x0109:0x2001:0x0102": {
+    "description": "Door Window Sensor",
+    "label": "ZD2102",
+    "manufacturer": "Vision Security"
+  },
+  "0x0109:0x2001:0x0103": {
+    "description": "Vision Security Door Sensor BR",
+    "label": "Door Sensor BR",
+    "manufacturer": "Vision Security"
+  },
+  "0x0109:0x2001:0x0104": {
+    "description": "Door Window Sensor",
+    "label": "ZD2102",
+    "manufacturer": "Vision Security"
+  },
+  "0x0109:0x2001:0x0105": {
+    "description": "Door Window Sensor",
+    "label": "ZD2102-5",
+    "manufacturer": "Vision Security"
+  },
+  "0x0109:0x2001:0x0106": {
+    "description": "Door Window Sensor",
+    "label": "ZD2102-5",
+    "manufacturer": "Vision Security"
+  },
+  "0x0109:0x2001:0x01a1": {
+    "description": "Door Contact",
+    "label": "ZD2112JP-5",
+    "manufacturer": "Vision Security"
+  },
+  "0x0109:0x2001:0x01a2": {
+    "description": "Door Contact",
+    "label": "ZD2112JP-5",
+    "manufacturer": "Vision Security"
+  },
+  "0x0109:0x2001:0x01a3": {
+    "description": "Door Contact",
+    "label": "ZD2112JP-5",
+    "manufacturer": "Vision Security"
+  },
+  "0x0109:0x2001:0x01d1": {
+    "description": "Door/Window Sensor",
+    "label": "ZD2106US-7",
+    "manufacturer": "Vision Security"
+  },
+  "0x0109:0x2002:0x0201": {
+    "description": "Motion Sensor",
+    "label": "ZP3102",
+    "manufacturer": "Vision Security"
+  },
+  "0x0109:0x2002:0x0202": {
+    "description": "Motion Sensor",
+    "label": "ZP3102",
+    "manufacturer": "Vision Security"
+  },
+  "0x0109:0x2002:0x0203": {
+    "description": "Motion Sensor",
+    "label": "ZP3102",
+    "manufacturer": "Vision Security"
+  },
+  "0x0109:0x2002:0x0204": {
+    "description": "Motion Sensor",
+    "label": "ZP3102",
+    "manufacturer": "Vision Security"
+  },
+  "0x0109:0x2002:0x0205": {
+    "description": "Motion/Temperature Sensor",
+    "label": "ZP3102",
+    "manufacturer": "Vision Security"
+  },
+  "0x0109:0x2003:0x0302": {
+    "description": "Shock Sensor",
+    "label": "ZP3103",
+    "manufacturer": "Vision Security"
+  },
+  "0x0109:0x2003:0x0306": {
+    "description": "Shock Sensor",
+    "label": "ZS5101",
+    "manufacturer": "Vision Security"
+  },
+  "0x0109:0x2003:0x0307": {
+    "description": "Shock Sensor",
+    "label": "ZS5101",
+    "manufacturer": "Vision Security"
+  },
+  "0x0109:0x2003:0x0308": {
+    "description": "Wireless Shock Sensor",
+    "label": "ZS5101US-5",
+    "manufacturer": "Vision Security"
+  },
+  "0x0109:0x2004:0x0403": {
+    "description": "Smoke Detector",
+    "label": "ZS6101",
+    "manufacturer": "Vision Security"
+  },
+  "0x0109:0x2004:0x0404": {
+    "description": "Smoke Detector",
+    "label": "ZS6102EU-5",
+    "manufacturer": "Vision Security"
+  },
+  "0x0109:0x2004:0x04a4": {
+    "description": "Smoke Detector",
+    "label": "ZS6101",
+    "manufacturer": "Vision Security"
+  },
+  "0x0109:0x2005:0x0503": {
+    "description": "AC/DC Siren",
+    "label": "ZM1602",
+    "manufacturer": "Vision Security"
+  },
+  "0x0109:0x2005:0x0505": {
+    "description": "Siren with LED strobe light",
+    "label": "ZM1601-5",
+    "manufacturer": "Vision Security"
+  },
+  "0x0109:0x2005:0x0508": {
+    "description": "Siren with LED strobe light",
+    "label": "ZM1601-5",
+    "manufacturer": "Vision Security"
+  },
+  "0x0109:0x2005:0x0518": {
+    "description": "Battery Operated Siren",
+    "label": "ZM1621",
+    "manufacturer": "Vision Security"
+  },
+  "0x0109:0x2005:0x05a0": {
+    "description": "U-Bell",
+    "label": "ZM1611JP-5",
+    "manufacturer": "Vision Security"
+  },
+  "0x0109:0x2006:0x0620": {
+    "description": "Door Lock with Handle",
+    "label": "ZM1702",
+    "manufacturer": "Vision Security"
+  },
+  "0x0109:0x2006:0x0621": {
+    "description": "Monoprice keypad door lock",
+    "label": "ZM1701",
+    "manufacturer": "Vision Security"
+  },
+  "0x0109:0x2006:0x0622": {
+    "description": "Monoprice keypad door lock",
+    "label": "ZM1701",
+    "manufacturer": "Vision Security"
+  },
+  "0x0109:0x2007:0x0703": {
+    "description": "Monoprice ZWave On/Off Plugin",
+    "label": "ZL7201",
+    "manufacturer": "Vision Security"
+  },
+  "0x0109:0x2007:0x0706": {
+    "description": "Plug-in On/Off Module",
+    "label": "ZL7201DE-5",
+    "manufacturer": "Vision Security"
+  },
+  "0x0109:0x2008:0x0801": {
+    "description": "Lamp Dimmer Module",
+    "label": "ZL7101",
+    "manufacturer": "Vision Security"
+  },
+  "0x0109:0x2008:0x0803": {
+    "description": "Monoprice ZWave Dimmer Plugin",
+    "label": "ZL7101",
+    "manufacturer": "Vision Security"
+  },
+  "0x0109:0x2009:0x0901": {
+    "description": "Wireless Siren & Strobe Alarm, Backup battery type",
+    "label": "ZM1602",
+    "manufacturer": "Vision Security"
+  },
+  "0x0109:0x2009:0x0903": {
+    "description": "AC/DC Siren",
+    "label": "ZM1602",
+    "manufacturer": "Vision Security"
+  },
+  "0x0109:0x2009:0x0907": {
+    "description": "Siren with DC adapter",
+    "label": "ZM1602-5",
+    "manufacturer": "Vision Security"
+  },
+  "0x0109:0x2009:0x0908": {
+    "description": "AC/DC Siren",
+    "label": "ZM1602",
+    "manufacturer": "Vision Security"
+  },
+  "0x0109:0x200a:0x0a01": {
+    "description": "Garage Door Tilt Sensor",
+    "label": "ZG8101",
+    "manufacturer": "Vision Security"
+  },
+  "0x0109:0x200a:0x0a02": {
+    "description": "Garage Door Tilt Sensor",
+    "label": "ZG8101",
+    "manufacturer": "Vision Security"
+  },
+  "0x0109:0x200c:0x0c02": {
+    "description": "In Wall Relay Switch",
+    "label": "ZL7431",
+    "manufacturer": "Vision Security"
+  },
+  "0x0109:0x200c:0x0c06": {
+    "description": "In-wall Switch",
+    "label": "ZL7434-5",
+    "manufacturer": "Vision Security"
+  },
+  "0x0109:0x200d:0x0d03": {
+    "description": "Drapery controller (up/stop/down)",
+    "label": "ZW4101",
+    "manufacturer": "Vision Security"
+  },
+  "0x0109:0x200f:0x0f03": {
+    "description": "CO Detector",
+    "label": "ZS6301",
+    "manufacturer": "Vision Security"
+  },
+  "0x0109:0x200f:0x0f04": {
+    "description": "Carbon monoxide detector",
+    "label": "ZS6301-5",
+    "manufacturer": "Vision Security"
+  },
+  "0x0109:0x2012:0x1203": {
+    "description": "Z-Wave Repeater",
+    "label": "ZR1202EU-5",
+    "manufacturer": "Vision Security"
+  },
+  "0x0109:0x2012:0x1206": {
+    "description": "Z-Wave Repeater",
+    "label": "ZR1202EU-5",
+    "manufacturer": "Vision Security"
+  },
+  "0x0109:0x2012:0x1207": {
+    "description": "Z-Wave Repeater",
+    "label": "ZR1202EU-5",
+    "manufacturer": "Vision Security"
+  },
+  "0x0109:0x2014:0x1401": {
+    "description": "Plug in Z-Wave to 433Mhz bridge plus lamp dimmer",
+    "label": "Z-BRDG-433",
+    "manufacturer": "Vision Security"
+  },
+  "0x0109:0x2016:0x1616": {
+    "description": "In Wall Relay Switch",
+    "label": "ZL7431",
+    "manufacturer": "Vision Security"
+  },
+  "0x0109:0x2017:0x1711": {
+    "description": "In Wall Dual Relay Switch",
+    "label": "ZL7432",
+    "manufacturer": "Vision Security"
+  },
+  "0x0109:0x2017:0x1717": {
+    "description": "In Wall Dual Relay Switch",
+    "label": "ZL7432",
+    "manufacturer": "Vision Security"
+  },
+  "0x0109:0x2017:0x1719": {
+    "description": "In-wall Two Relay",
+    "label": "ZL7435-5",
+    "manufacturer": "Vision Security"
+  },
+  "0x0109:0x2018:0x1805": {
+    "description": "Curtain Module",
+    "label": "ZW4111EU-5",
+    "manufacturer": "Vision Security"
+  },
+  "0x0109:0x201a:0x1aa4": {
+    "description": "Plug In Power Monitor",
+    "label": "PID15903",
+    "manufacturer": "Vision Security"
+  },
+  "0x0109:0x201b:0x1b02": {
+    "description": "Keyfob",
+    "label": "ZT1101",
+    "manufacturer": "Vision Security"
+  },
+  "0x0109:0x201c:0x1c03": {
+    "description": "Vision Flood Sensor",
+    "label": "ZF5201EU-5",
+    "manufacturer": "Vision Security"
+  },
+  "0x0109:0x201f:0x1f10": {
+    "description": "Multisensor 4in1",
+    "label": "ZD2201",
+    "manufacturer": "Vision Security"
+  },
+  "0x0109:0x201f:0x1f20": {
+    "description": "4 in 1 Door Sensor",
+    "label": "ZD2301EU-5",
+    "manufacturer": "Vision Security"
+  },
+  "0x0109:0x2021:0x2101": {
+    "description": "Zooz 4-in-one motion/temperature/humidity/luminance sensor",
+    "label": "ZSE40",
+    "manufacturer": "Vision Security"
+  },
+  "0x0109:0x2022:0x2201": {
+    "description": "Recessed Door Window Sensor",
+    "label": "ZD2105",
+    "manufacturer": "Vision Security"
+  },
+  "0x0109:0x2022:0x2202": {
+    "description": "Recessed Door Window Sensor",
+    "label": "ZD2105",
+    "manufacturer": "Vision Security"
+  },
+  "0x0109:0x202f:0x2f01": {
+    "description": "Glass Break Detector",
+    "label": "ZB5311US-5",
+    "manufacturer": "Vision Security"
+  },
+  "0x010a:0x1100:0x4900": {
+    "description": "Vitrum I dimmer wireless",
+    "label": "VITRUM I",
+    "manufacturer": "VDA"
+  },
+  "0x010a:0x1100:0x4a00": {
+    "description": "Vitrum II dimmer wireless",
+    "label": "VITRUM II",
+    "manufacturer": "VDA"
+  },
+  "0x010a:0x1100:0x4b00": {
+    "description": "",
+    "label": "Vitrum III EU Dimmer",
+    "manufacturer": "VDA"
+  },
+  "0x010a:0x1200:0x5100": {
+    "description": "Vitrum touch switch Relay",
+    "label": "Vitrum I EU switch",
+    "manufacturer": "VDA"
+  },
+  "0x010a:0x1200:0x5200": {
+    "description": "Vitrum II EU on-off wireless",
+    "label": "VITRUM II SWITCH",
+    "manufacturer": "VDA"
+  },
+  "0x010a:0x1300:0x5a00": {
+    "description": "VITRUM II Control of Roller Blinds - EU BOX",
+    "label": "VITRIUM II Roller Blinds",
+    "manufacturer": "VDA"
+  },
+  "0x010a:0x1400:0x6600": {
+    "description": "Vitrum touch switch satellite 6 buttons",
+    "label": "Vitrum Satellite VI",
+    "manufacturer": "VDA"
+  },
+  "0x010a:0x1500:0x6900": {
+    "description": "Vitrum Scenario controller",
+    "label": "Vitrum Scenario",
+    "manufacturer": "VDA"
+  },
+  "0x010a:0x2100:0x8900": {
+    "description": "Vitrum I dimmer wireless",
+    "label": "VITRUM I",
+    "manufacturer": "VDA"
+  },
+  "0x010a:0x2100:0x8a00": {
+    "description": "Vitrum II dimmer wireless",
+    "label": "VITRUM II",
+    "manufacturer": "VDA"
+  },
+  "0x010a:0x3400:0x6400": {
+    "description": "Vitrum touch switch satellite 4 buttons",
+    "label": "Vitrum Satellite IV",
+    "manufacturer": "VDA"
+  },
+  "0x010a:0x7001:0x0f02": {
+    "description": "Vitrum touch switch Relay",
+    "label": "Vitrum I EU switch",
+    "manufacturer": "VDA"
+  },
+  "0x010a:0x7032:0x0f33": {
+    "description": "Vitrum touch timer switch Dual Relay",
+    "label": "Vitrum I EU Boiler",
+    "manufacturer": "VDA"
+  },
+  "0x010a:0x8161:0x2062": {
+    "description": "Vitrum VI EU on-off 6 triac 868.4MHz",
+    "label": "01E06S263",
+    "manufacturer": "VDA"
+  },
+  "0x010b:0x4561:0x0074": {
+    "description": "IoT Gateway",
+    "label": "DN3E6JE074",
+    "manufacturer": "Sharp"
+  },
+  "0x010b:0x4561:0x0087": {
+    "description": "Z-Wave Gateway",
+    "label": "DN3E6JA087",
+    "manufacturer": "Sharp"
+  },
+  "0x010b:0x4561:0x0088": {
+    "description": "3G Gateway",
+    "label": "3G Gateway",
+    "manufacturer": "Sharp"
+  },
+  "0x010b:0x4561:0x0089": {
+    "description": "IoT Gateway",
+    "label": "IoT Gateway",
+    "manufacturer": "Sharp"
+  },
+  "0x010b:0x4761:0x0069": {
+    "description": "Multi Sensor",
+    "label": "DN3G6JA069",
+    "manufacturer": "Sharp"
+  },
+  "0x010b:0x4761:0x0082": {
+    "description": "Open/Close Sensor",
+    "label": "DN3G6JA082",
+    "manufacturer": "Sharp"
+  },
+  "0x010b:0x4761:0x0084": {
+    "description": "Motion Detect Sensor",
+    "label": "DN3G6JA084",
+    "manufacturer": "Sharp"
+  },
+  "0x010c:0x0001:0x0001": {
+    "description": "ThereGate Gateway Controller",
+    "label": "Gateway Controller",
+    "manufacturer": "There Corporation"
+  },
+  "0x010e:0x0003:0x0002": {
+    "description": "Danalock v2 circle",
+    "label": "BTZW125",
+    "manufacturer": "Poly-control"
+  },
+  "0x010e:0x0008:0x0002": {
+    "description": "Danalock v2 circle",
+    "label": "BTZW125",
+    "manufacturer": "Poly-control"
+  },
+  "0x010e:0x0008:0x0004": {
+    "description": "Danalock Universal Module V1",
+    "label": "BTZEUMV1",
+    "manufacturer": "Poly-control"
+  },
+  "0x010e:0x0009:0x0001": {
+    "description": "Z-Wave controlled door lock with Bluetooth Smart",
+    "label": "Danalock V3-BTZE",
+    "manufacturer": "Poly-control"
+  },
+  "0x010e:0x0009:0x0002": {
+    "description": "Danalock Universal Module V3",
+    "label": "UMV3-BTZ",
+    "manufacturer": "Poly-control"
+  },
+  "0x010f:0x0000:0x1000": {
+    "description": "FIBARO Smoke Sensor",
+    "label": "Smoke Sensor",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0000:0x1001": {
+    "description": "FIBARO Flood Sensor",
+    "label": "FGFS-101 ()",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0000:0x2001": {
+    "description": "FIBARO Flood Sensor",
+    "label": "FGFS-101 ()",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0001:0x1001": {
+    "description": "FIBARO",
+    "label": "HC2",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0002:0x1000": {
+    "description": "FIBARO Home Center Lite",
+    "label": "HCL",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0002:0x1001": {
+    "description": "FIBARO Home Center Lite",
+    "label": "HCL",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0100:0x0100": {
+    "description": "FIBARO Universal Dimmer 500W",
+    "label": "Universal Dimmer 500W",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0100:0x0104": {
+    "description": "Universal Dimmer 500W",
+    "label": "FGD211",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0100:0x0106": {
+    "description": "Universal Dimmer 500W",
+    "label": "FGD211",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0100:0x0107": {
+    "description": "Universal Dimmer 500W",
+    "label": "FGD211",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0100:0x0109": {
+    "description": "Universal Dimmer 500W",
+    "label": "FGD211",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0100:0x100a": {
+    "description": "Universal Dimmer 500W",
+    "label": "FGD211",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0100:0x300a": {
+    "description": "Universal Dimmer 500W",
+    "label": "FGD211",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0100:0x400a": {
+    "description": "Universal Dimmer 500W",
+    "label": "FGD211",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0102:0x1000": {
+    "description": "Dimmer 2",
+    "label": "FGD212",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0102:0x2000": {
+    "description": "Dimmer 2",
+    "label": "FGD212",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0102:0x3000": {
+    "description": "Dimmer 2",
+    "label": "FGD212",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0102:0x4000": {
+    "description": "Dimmer 2",
+    "label": "FGD212",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0102:0x6000": {
+    "description": "Dimmer 2",
+    "label": "FGD212",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x010f:0x1c01": {
+    "description": "Fibaro Walli Dimmer",
+    "label": "FGWDEU",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0200:0x0102": {
+    "description": "Double Relay Switch 2x1.5kW",
+    "label": "FGS211 / FGS221",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0200:0x0103": {
+    "description": "Double Relay Switch 2x1.5kW",
+    "label": "FGS211 / FGS221",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0200:0x0104": {
+    "description": "Double Relay Switch 2x1.5kW",
+    "label": "FGS211 / FGS221",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0200:0x0105": {
+    "description": "Double Relay Switch 2x1.5kW",
+    "label": "FGS211 / FGS221",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0200:0x0106": {
+    "description": "Double Relay Switch 2x1.5kW",
+    "label": "FGS211 / FGS221",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0200:0x0107": {
+    "description": "Double Relay Switch 2x1.5kW",
+    "label": "FGS211 / FGS221",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0200:0x0109": {
+    "description": "Double Relay Switch 2x1.5kW",
+    "label": "FGS211 / FGS221",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0200:0x100a": {
+    "description": "Double Relay Switch 2x1.5kW",
+    "label": "FGS211 / FGS221",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0200:0x300a": {
+    "description": "Double Relay Switch 2x1.5kW",
+    "label": "FGS211 / FGS221",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0202:0x1002": {
+    "description": "Double Relay Switch 2x1.5kW",
+    "label": "FGS222",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0202:0x3002": {
+    "description": "Double Relay Switch 2x1.5kW",
+    "label": "FGS211 / FGS221",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0202:0x4002": {
+    "description": "Double Relay Switch 2x1.5kW",
+    "label": "FGS222",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0202:0x6002": {
+    "description": "Double Relay Switch 2x1.5kW",
+    "label": "FGS222",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0203:0x1000": {
+    "description": "Double Switch 2",
+    "label": "FGS223",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0203:0x2000": {
+    "description": "Double Switch 2",
+    "label": "FGS223",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0203:0x3000": {
+    "description": "Double Switch 2",
+    "label": "FGS223",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0203:0x4000": {
+    "description": "Double Switch 2",
+    "label": "FGS223",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0203:0x6000": {
+    "description": "Double Switch 2",
+    "label": "FGS223",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0204:0x1000": {
+    "description": "Double Smart Module",
+    "label": "FGS224",
+    "manufacturer": "FIBARO System"
+  },
+  "0x010f:0x0300:0x0102": {
+    "description": "Roller Shutter 2",
+    "label": "FGR222",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0300:0x0104": {
+    "description": "Roller Shutter Controller",
+    "label": "FGR221",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0300:0x0106": {
+    "description": "Roller Shutter Controller",
+    "label": "FGR221",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0300:0x0107": {
+    "description": "Roller Shutter Controller",
+    "label": "FGR221",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0300:0x0109": {
+    "description": "Roller Shutter Controller",
+    "label": "FGR221",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0300:0x100a": {
+    "description": "Roller Shutter Controller",
+    "label": "FGR221",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0301:0x1001": {
+    "description": "Roller Shutter",
+    "label": "FGRM222",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0301:0x3001": {
+    "description": "Roller Shutter",
+    "label": "FGRM222",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0302:0x1000": {
+    "description": "Roller Shutter",
+    "label": "FGRM222",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0302:0x3000": {
+    "description": "Roller Shutter 2",
+    "label": "FGR222",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0302:0x4000": {
+    "description": "Roller Shutter 2",
+    "label": "FGR222",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0303:0x1000": {
+    "description": "Roller Shutter 3",
+    "label": "FGR223",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0303:0x3000": {
+    "description": "Roller Shutter 3",
+    "label": "FGR223",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0400:0x0102": {
+    "description": "Relay Switch 1x3kW",
+    "label": "FGS211",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0400:0x0104": {
+    "description": "Relay Switch 1x3kW",
+    "label": "FGS211",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0400:0x0105": {
+    "description": "Relay Switch 1x3kW",
+    "label": "FGS211",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0400:0x0106": {
+    "description": "Relay Switch 1x3kW",
+    "label": "FGS211",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0400:0x0107": {
+    "description": "Relay Switch 1x3kW",
+    "label": "FGS211",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0400:0x0108": {
+    "description": "Relay Switch 1x3kW",
+    "label": "FGS211",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0400:0x0109": {
+    "description": "Relay Switch 1x3kW",
+    "label": "FGS211",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0400:0x100a": {
+    "description": "Relay Switch 1x3kW",
+    "label": "FGS211",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0400:0x300a": {
+    "description": "Relay Switch 1x3kW",
+    "label": "FGS211",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0401:0x100a": {
+    "description": "Relay Switch 1x2.5kW",
+    "label": "FGS212",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0402:0x1002": {
+    "description": "Relay Switch 1x2.5kW",
+    "label": "FGS212",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0402:0x3002": {
+    "description": "Relay Switch 1x3kW",
+    "label": "FGS211",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0403:0x1000": {
+    "description": "Single Switch 2",
+    "label": "FGS213",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0403:0x2000": {
+    "description": "Single Switch 2",
+    "label": "FGS213",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0403:0x3000": {
+    "description": "Single Switch 2",
+    "label": "FGS213",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0403:0x6000": {
+    "description": "Single Switch 2",
+    "label": "FGS213",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0404:0x1000": {
+    "description": "Smart Module",
+    "label": "FGS214",
+    "manufacturer": "FIBARO System"
+  },
+  "0x010f:0x0501:0x0102": {
+    "description": "Universal Binary Sensor",
+    "label": "FGBS001",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0501:0x0109": {
+    "description": "Universal Binary Sensor",
+    "label": "FGBS001",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0501:0x1002": {
+    "description": "Universal Binary Sensor",
+    "label": "FGBS001",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0501:0x2002": {
+    "description": "Universal Binary Sensor",
+    "label": "FGBS001",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0501:0x3002": {
+    "description": "Universal Binary Sensor",
+    "label": "FGBS001",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0501:0x4002": {
+    "description": "Universal Binary Sensor",
+    "label": "FGBS001",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0502:0x1000": {
+    "description": "Smart Implant",
+    "label": "FGBS222",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0502:0x2000": {
+    "description": "Smart Implant",
+    "label": "FGBS222",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0502:0x3000": {
+    "description": "Smart Implant",
+    "label": "FGBS222",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0600:0x1000": {
+    "description": "Metered Wall Plug Switch",
+    "label": "FGWPE/F-101",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0602:0x1001": {
+    "description": "Metered Wall Plug Switch",
+    "label": "FGWP102",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0602:0x1003": {
+    "description": "Metered Wall Plug Switch",
+    "label": "FGWP102",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0700:0x1000": {
+    "description": "Door Opening Sensor",
+    "label": "FGK101",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0700:0x2000": {
+    "description": "Door Opening Sensor",
+    "label": "FGK101",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0700:0x3000": {
+    "description": "Door Opening Sensor",
+    "label": "FGK101",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0701:0x1001": {
+    "description": "Door Opening Sensor",
+    "label": "FGK101",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0701:0x2001": {
+    "description": "Door Opening Sensor",
+    "label": "FGK101",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0701:0x3001": {
+    "description": "Door Opening Sensor",
+    "label": "FGK101",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0702:0x1000": {
+    "description": "Fibaro Door Window Sensor 2",
+    "label": "FGDW002",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0702:0x2000": {
+    "description": "Fibaro Door Window Sensor 2",
+    "label": "FGDW002",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0702:0x3000": {
+    "description": "Fibaro Door Window Sensor 2",
+    "label": "FGDW002",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0702:0x7000": {
+    "description": "Fibaro Door Window Sensor 2",
+    "label": "FGDW002",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0800:0x1001": {
+    "description": "Motion Sensor",
+    "label": "FGMS001",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0800:0x2001": {
+    "description": "Motion Sensor",
+    "label": "FGMS001",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0800:0x3001": {
+    "description": "Motion Sensor",
+    "label": "FGMS001",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0800:0x4001": {
+    "description": "Motion Sensor",
+    "label": "FGMS001",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0800:0x6001": {
+    "description": "Motion Sensor",
+    "label": "FGMS001",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0801:0x1001": {
+    "description": "Motion Sensor",
+    "label": "FGMS001",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0801:0x1002": {
+    "description": "Motion Sensor",
+    "label": "FGMS001",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0801:0x2001": {
+    "description": "Motion Sensor",
+    "label": "FGMS001",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0801:0x2002": {
+    "description": "Motion Sensor",
+    "label": "FGMS001",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0801:0x3001": {
+    "description": "Motion Sensor",
+    "label": "FGMS001",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0801:0x3002": {
+    "description": "Motion Sensor",
+    "label": "FGMS001",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0801:0x4001": {
+    "description": "Motion Sensor",
+    "label": "FGMS001",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0801:0x4002": {
+    "description": "Motion Sensor",
+    "label": "FGMS001",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0900:0x1000": {
+    "description": "RGBW Controller",
+    "label": "FGRGBW",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0900:0x2000": {
+    "description": "RGBW Controller",
+    "label": "FGRGBW",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0900:0x3000": {
+    "description": "RGBW Controller",
+    "label": "FGRGBW",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0900:0x4000": {
+    "description": "RGBW Controller",
+    "label": "FGRGBW",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0902:0x1000": {
+    "description": "RGBW CONTROLLER 2",
+    "label": "FGRGBW-442",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0b00:0x1001": {
+    "description": "Flood Sensor",
+    "label": "FGFS101",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0b00:0x2001": {
+    "description": "Flood Sensor",
+    "label": "FGFS101",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0b00:0x3001": {
+    "description": "Flood Sensor",
+    "label": "FGFS101",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0b01:0x1002": {
+    "description": "Flood Sensor",
+    "label": "FGFS101",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0b01:0x1003": {
+    "description": "Flood Sensor",
+    "label": "FGFS101",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0b01:0x2002": {
+    "description": "Flood Sensor",
+    "label": "FGFS101",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0b01:0x3002": {
+    "description": "Flood Sensor",
+    "label": "FGFS101",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0c00:0x1000": {
+    "description": "Smoke Sensor",
+    "label": "FGSS001",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0c00:0x3000": {
+    "description": "Smoke Sensor",
+    "label": "FGSS001",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0c02:0x1002": {
+    "description": "Smoke Detector",
+    "label": "FGSD002",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0c02:0x1003": {
+    "description": "Smoke Detector",
+    "label": "FGSD002",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0c02:0x4002": {
+    "description": "Smoke Detector",
+    "label": "FGSD002",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0d01:0x1000": {
+    "description": "Fibaro Swipe Scene Controller",
+    "label": "FGGC001",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0d01:0x2000": {
+    "description": "Fibaro Swipe Scene Controller",
+    "label": "FGGC001",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0d01:0x3000": {
+    "description": "Fibaro Swipe Scene Controller",
+    "label": "FGGC001",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0f01:0x1000": {
+    "description": "A real push button (switch) available in several colors.",
+    "label": "FGPB-101",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0f01:0x2000": {
+    "description": "A real push button (switch) available in several colors.",
+    "label": "FGPB-101",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0f01:0x3000": {
+    "description": "A real push button (switch) available in several colors.",
+    "label": "FGPB-101",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0f01:0x4000": {
+    "description": "A real push button (switch) available in several colors.",
+    "label": "FGPB-101",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0f01:0x6000": {
+    "description": "A real push button (switch) available in several colors.",
+    "label": "FGPB-101",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0f01:0x7000": {
+    "description": "A real push button (switch) available in several colors.",
+    "label": "FGPB-101",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0f01:0x8000": {
+    "description": "A real push button (switch) available in several colors.",
+    "label": "FGPB-101",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0f01:0x9000": {
+    "description": "A real push button (switch) available in several colors.",
+    "label": "FGPB-101",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0f01:0xa000": {
+    "description": "A real push button (switch) available in several colors.",
+    "label": "FGPB-101",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x0f01:0xb000": {
+    "description": "A real push button (switch) available in several colors.",
+    "label": "FGPB-101",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x1001:0x1000": {
+    "description": "Keyfob",
+    "label": "FGKF601",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x1001:0x2000": {
+    "description": "Keyfob",
+    "label": "FGKF601",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x1001:0x3000": {
+    "description": "Keyfob",
+    "label": "FGKF601",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x1201:0x1000": {
+    "description": "Carbon Monoxide Sensor",
+    "label": "FGCD001",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x1201:0x1001": {
+    "description": "Carbon Monoxide Sensor",
+    "label": "FGCD001",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x1301:0x1000": {
+    "description": "Thermostatic Valve",
+    "label": "FGT001",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x1301:0x1001": {
+    "description": "Thermostatic Valve",
+    "label": "FGT001",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x1401:0x2000": {
+    "description": "Fibaro Wall Plug",
+    "label": "FGWPB-121",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x1701:0x2000": {
+    "description": "FIBARO Wall Plug",
+    "label": "FGWPB-111",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x1801:0x1000": {
+    "description": "Fibaro Wall Plug",
+    "label": "FGWPB-121",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x1a01:0x1000": {
+    "description": "WALLI SWITCH FIBARO SINGLE SWITCH",
+    "label": "FGWDS",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x1b01:0x1000": {
+    "description": "WALLI SWITCH FIBARO DOUBLE SWITCH",
+    "label": "FGWDSEU",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x1c01:0x1000": {
+    "description": "Fibaro Walli Dimmer",
+    "label": "FGWDEU",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x1d01:0x1000": {
+    "description": "Fibaro Walli Roller Shutter",
+    "label": "FGWREU-111",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x1f01:0x1000": {
+    "description": "Fibaro Walli Outlet type E/F",
+    "label": "FGWOE-011",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0x8800:0x3001": {
+    "description": "Motion Sensor",
+    "label": "FGMS001",
+    "manufacturer": "Fibargroup"
+  },
+  "0x010f:0xfb10:0x1014": {
+    "description": "A real push button (switch) available in several colors.",
+    "label": "FGPB-101",
+    "manufacturer": "Fibargroup"
+  },
+  "0x0110:0x2411:0x0001": {
+    "description": "nanogrid\u2122 Wireless Light Switch",
+    "label": "FDN2311",
+    "manufacturer": "Frostdale"
+  },
+  "0x0110:0x7333:0x0031": {
+    "description": "3way switch with temp sensor",
+    "label": "FDN2300",
+    "manufacturer": "Frostdale"
+  },
+  "0x0111:0x1000:0x0010": {
+    "description": "Tronico SmartPlug",
+    "label": "SPZ7113",
+    "manufacturer": "Tronico Technology Co. Ltd."
+  },
+  "0x0111:0x8200:0x0200": {
+    "description": "Dimming Switch Module",
+    "label": "NDS/ZDS-UD10",
+    "manufacturer": "Tronico Technology Co. Ltd."
+  },
+  "0x0111:0x8800:0x0101": {
+    "description": "Binary Switch",
+    "label": "Binary Switch",
+    "manufacturer": "Tronico Technology Co. Ltd."
+  },
+  "0x0111:0x8801:0x0201": {
+    "description": "Switch-Dimmer",
+    "label": "NB012",
+    "manufacturer": "Tronico Technology Co. Ltd."
+  },
+  "0x0112:0x0001:0x0001": {
+    "description": "",
+    "label": "ITB-5088",
+    "manufacturer": "MITSUMI"
+  },
+  "0x0113:0x0002:0x0036": {
+    "description": "Recessed Door Sensor",
+    "label": "Recessed Door Sensor",
+    "manufacturer": "Evolve"
+  },
+  "0x0113:0x4450:0x3030": {
+    "description": "Lamp Module",
+    "label": "LDM-15W",
+    "manufacturer": "Evolve"
+  },
+  "0x0113:0x4457:0x3034": {
+    "description": "Wall Mounted Dimmer",
+    "label": "LRM-AS",
+    "manufacturer": "Evolve"
+  },
+  "0x0113:0x4556:0x4c32": {
+    "description": "Evolve Single Gang RF Scene Controller",
+    "label": "EVLCD1 RF Scene Controller",
+    "manufacturer": "Evolve"
+  },
+  "0x0113:0x4556:0x5434": {
+    "description": "Thermostat",
+    "label": "T100",
+    "manufacturer": "Evolve"
+  },
+  "0x0113:0x4556:0x5435": {
+    "description": "Thermostat",
+    "label": "T100",
+    "manufacturer": "Evolve"
+  },
+  "0x0113:0x5246:0x3133": {
+    "description": "",
+    "label": "LFM-20",
+    "manufacturer": "Evolve"
+  },
+  "0x0113:0x5250:0x3030": {
+    "description": "Appliance module",
+    "label": "LPM-15",
+    "manufacturer": "Evolve"
+  },
+  "0x0113:0x5252:0x3530": {
+    "description": "Duplex Receptacle",
+    "label": "LOM15",
+    "manufacturer": "Evolve"
+  },
+  "0x0113:0x5257:0x3533": {
+    "description": "Wall Mounted Switch",
+    "label": "LSM-15",
+    "manufacturer": "Evolve"
+  },
+  "0x0113:0x5457:0x3033": {
+    "description": "Wall Mount Accessory Switch",
+    "label": "LTM-5",
+    "manufacturer": "Evolve"
+  },
+  "0x0114:0x0001:0x0001": {
+    "description": "Design Pro LED Z Wave Dimmer Module",
+    "label": "12387",
+    "manufacturer": "Kichler"
+  },
+  "0x0114:0xb005:0x3b60": {
+    "description": "200W Design Pro LED Controller",
+    "label": "15DC200",
+    "manufacturer": "Kichler"
+  },
+  "0x0114:0xb005:0x3bc4": {
+    "description": "Kichler - LVPS Switch",
+    "label": "LVPS Switch",
+    "manufacturer": "Kichler"
+  },
+  "0x0115:0x0000:0x0000": {
+    "description": "USB Z-Wave Mini Adapter",
+    "label": "ZME_UZB1",
+    "manufacturer": "Z-Wave.Me"
+  },
+  "0x0115:0x0001:0x0001": {
+    "description": "Razberry500",
+    "label": "Razberry500",
+    "manufacturer": "Z-Wave.Me"
+  },
+  "0x0115:0x0024:0x0001": {
+    "description": "Floor Thermostat",
+    "label": "ZME_FT",
+    "manufacturer": "Z-Wave.Me"
+  },
+  "0x0115:0x0100:0x0001": {
+    "description": "4 button keyfob",
+    "label": "KFOB",
+    "manufacturer": "Z-Wave.Me"
+  },
+  "0x0115:0x0100:0x0002": {
+    "description": "4 button keyfob",
+    "label": "KFOB",
+    "manufacturer": "Z-Wave.Me"
+  },
+  "0x0115:0x0100:0x0004": {
+    "description": "Double Paddle Wall Controller",
+    "label": "WCD2",
+    "manufacturer": "Z-Wave.Me"
+  },
+  "0x0115:0x0100:0x0101": {
+    "description": "Wall Controller",
+    "label": "WALLC-S",
+    "manufacturer": "Z-Wave.Me"
+  },
+  "0x0115:0x0100:0x0102": {
+    "description": "Secure 4 Button Key Chain Controller",
+    "label": "ZME_KFOB-S",
+    "manufacturer": "Z-Wave.Me"
+  },
+  "0x0115:0x0100:0x0103": {
+    "description": "Secure 4 Button Key Chain Controller",
+    "label": "ZME_KFOB-S",
+    "manufacturer": "Z-Wave.Me"
+  },
+  "0x0115:0x0100:0x0400": {
+    "description": "Z-Wave weather interface",
+    "label": "Z-Weather",
+    "manufacturer": "Z-Wave.Me"
+  },
+  "0x0115:0x0110:0x0001": {
+    "description": "Z-Uno",
+    "label": "V3",
+    "manufacturer": "Z-Wave.Me"
+  },
+  "0x0115:0x0111:0x0001": {
+    "description": "DIN Rail 6x2kW Universal Switch / 4xInputs",
+    "label": "FGR-316",
+    "manufacturer": "Z-Wave.Me"
+  },
+  "0x0115:0x0115:0x0001": {
+    "description": "DIN Rail 6x2kW Universal Switch / 4xInputs",
+    "label": "FGR-316",
+    "manufacturer": "Z-Wave.Me"
+  },
+  "0x0115:0x0116:0x0001": {
+    "description": "DIN Rail 6x2kW Universal Switch / 4xInputs",
+    "label": "FGR-316",
+    "manufacturer": "Z-Wave.Me"
+  },
+  "0x0115:0x0400:0x0001": {
+    "description": "Z-Wave USB Stick",
+    "label": "UZB",
+    "manufacturer": "Z-Wave.Me"
+  },
+  "0x0115:0x0400:0x0004": {
+    "description": "Single Paddle Wall Controller",
+    "label": "ZME_06443",
+    "manufacturer": "Z-Wave.Me"
+  },
+  "0x0115:0x1000:0x0001": {
+    "description": "Flush mountable switch",
+    "label": "ZME_06431",
+    "manufacturer": "Z-Wave.Me"
+  },
+  "0x0115:0x1000:0x0002": {
+    "description": "Zwave.Me Dimmer Set Everlux",
+    "label": "ZME_06433",
+    "manufacturer": "Z-Wave.Me"
+  },
+  "0x0115:0x1000:0x0003": {
+    "description": "Flush Mountable Blind Control",
+    "label": "ZME_06436",
+    "manufacturer": "Z-Wave.Me"
+  },
+  "0x0115:0x1000:0x0004": {
+    "description": "Single Paddle Wall Controller",
+    "label": "ZME_06443",
+    "manufacturer": "Z-Wave.Me"
+  },
+  "0x0115:0x1000:0x0100": {
+    "description": "Double switch",
+    "label": "ZME_05461",
+    "manufacturer": "Z-Wave.Me"
+  },
+  "0x0115:0x1000:0x0200": {
+    "description": "Wall Plug Switch",
+    "label": "ZME_06437",
+    "manufacturer": "Z-Wave.Me"
+  },
+  "0x0115:0x1000:0x0300": {
+    "description": "Z-Wave Remote Control+",
+    "label": "ZME_RC2",
+    "manufacturer": "Z-Wave.Me"
+  },
+  "0x0115:0xf222:0x2111": {
+    "description": "4x Relay and 4x Universal Dimmer",
+    "label": "R4D4",
+    "manufacturer": "Haseman"
+  },
+  "0x0115:0xffff:0xffff": {
+    "description": "Blinds controller",
+    "label": "ZME_05459",
+    "manufacturer": "Z-Wave.Me"
+  },
+  "0x0116:0x0001:0x0001": {
+    "description": "Motion Detector",
+    "label": "HSP02",
+    "manufacturer": "Chromagic Technologies Corporation"
+  },
+  "0x0116:0x0002:0x0001": {
+    "description": "Door Window Sensor",
+    "label": "HSM02",
+    "manufacturer": "Chromagic Technologies Corporation"
+  },
+  "0x0116:0x0010:0x0001": {
+    "description": "Chromagic Z-Wave Remote Botton (EU)",
+    "label": "HAC01",
+    "manufacturer": "Chromagic Technologies Corporation"
+  },
+  "0x0116:0x0011:0x0001": {
+    "description": "In wall single switch",
+    "label": "HAN01",
+    "manufacturer": "Chromagic Technologies Corporation"
+  },
+  "0x0116:0x0011:0x0002": {
+    "description": "-1 - Z-Wave In Wall Switch",
+    "label": "HAN02",
+    "manufacturer": "Chromagic Technologies Corporation"
+  },
+  "0x0116:0x1182:0x4501": {
+    "description": "Contact and temperature sensor",
+    "label": "ITEMP",
+    "manufacturer": "Chromagic Technologies Corporation"
+  },
+  "0x0116:0x1188:0x4501": {
+    "description": "Contact and temperature sensor",
+    "label": "ITEMP",
+    "manufacturer": "Chromagic Technologies Corporation"
+  },
+  "0x0117:0x0001:0x0080": {
+    "description": "Gewa Andromeda Socket",
+    "label": "419880",
+    "manufacturer": "Abilia"
+  },
+  "0x0118:0x0001:0x0001": {
+    "description": "Energy Monitoring Wall Plug",
+    "label": "TZ88",
+    "manufacturer": "TKB Home"
+  },
+  "0x0118:0x0001:0x0003": {
+    "description": "In Wall Dual Relay Switch",
+    "label": "TZ04U",
+    "manufacturer": "TKB Home"
+  },
+  "0x0118:0x0001:0x0004": {
+    "description": "In Wall Dual Relay(1 Way) Switch Module 2x 1.5kW",
+    "label": "TZ06",
+    "manufacturer": "TKB Home"
+  },
+  "0x0118:0x0001:0x0006": {
+    "description": "Rollershutter Controller",
+    "label": "TZ08",
+    "manufacturer": "TKB Home"
+  },
+  "0x0118:0x0001:0x0011": {
+    "description": "Energy Monitoring Wall Plug",
+    "label": "TZ88",
+    "manufacturer": "TKB Home"
+  },
+  "0x0118:0x0002:0x0002": {
+    "description": "Slim Multi-Sensor",
+    "label": "TSM02",
+    "manufacturer": "TKB Home"
+  },
+  "0x0118:0x0003:0x0002": {
+    "description": "Wall Plug",
+    "label": "TZ68",
+    "manufacturer": "TKB Home"
+  },
+  "0x0118:0x0003:0x0003": {
+    "description": "Dual Paddle Wall Switch",
+    "label": "TZ36D",
+    "manufacturer": "TKB Home"
+  },
+  "0x0118:0x0003:0x0004": {
+    "description": "Dual Paddle Wall Dimmer",
+    "label": "TZ55D",
+    "manufacturer": "TKB Home"
+  },
+  "0x0118:0x0003:0x0005": {
+    "description": "In Wall Micro Switch",
+    "label": "TZ78",
+    "manufacturer": "TKB Home"
+  },
+  "0x0118:0x0003:0x0008": {
+    "description": "Wall Plug Dimmer",
+    "label": "TZ67",
+    "manufacturer": "TKB Home"
+  },
+  "0x0118:0x0004:0x0002": {
+    "description": "Smart meter switch",
+    "label": "TZ69",
+    "manufacturer": "TKB Home"
+  },
+  "0x0118:0x0004:0x0003": {
+    "description": "Dual Paddle Wall Dimmer",
+    "label": "TZ65D",
+    "manufacturer": "TKB Home"
+  },
+  "0x0118:0x0101:0x0103": {
+    "description": "Wall Plug",
+    "label": "TZ68",
+    "manufacturer": "TKB Home"
+  },
+  "0x0118:0x0102:0x1020": {
+    "description": "Dual Paddle Wall Switch",
+    "label": "TZ66",
+    "manufacturer": "TKB Home"
+  },
+  "0x0118:0x0102:0x1036": {
+    "description": "TKB Switch D",
+    "label": "TZ36",
+    "manufacturer": "TKB Home"
+  },
+  "0x0118:0x0102:0x1056": {
+    "description": "TKB Switch",
+    "label": "TZ56S",
+    "manufacturer": "TKB Home"
+  },
+  "0x0118:0x0102:0x2036": {
+    "description": "TKB Switch D",
+    "label": "TZ36",
+    "manufacturer": "TKB Home"
+  },
+  "0x0118:0x0102:0x2056": {
+    "description": "TKB Switch D",
+    "label": "TZ56",
+    "manufacturer": "TKB Home"
+  },
+  "0x0118:0x0116:0x3119": {
+    "description": "Smart meter switch",
+    "label": "TZ69",
+    "manufacturer": "TKB Home"
+  },
+  "0x0118:0x0121:0x0133": {
+    "description": "In Wall Micro Switch",
+    "label": "TZ78",
+    "manufacturer": "TKB Home"
+  },
+  "0x0118:0x0201:0x0501": {
+    "description": "Thermostat with LCD Screen",
+    "label": "TZ10",
+    "manufacturer": "TKB Home"
+  },
+  "0x0118:0x0202:0x0511": {
+    "description": "Wall Plug",
+    "label": "TZ68",
+    "manufacturer": "TKB Home"
+  },
+  "0x0118:0x0202:0x0611": {
+    "description": "Wall Plug Dimmer",
+    "label": "TZ67",
+    "manufacturer": "TKB Home"
+  },
+  "0x0118:0x0311:0x0103": {
+    "description": "Smart meter switch",
+    "label": "TZ69",
+    "manufacturer": "TKB Home"
+  },
+  "0x0118:0x0311:0x0201": {
+    "description": "Dual Paddle Wall Dimmer",
+    "label": "TZ55D",
+    "manufacturer": "TKB Home"
+  },
+  "0x0118:0x0311:0x0202": {
+    "description": "Dual Paddle Wall Switch",
+    "label": "TZ36D",
+    "manufacturer": "TKB Home"
+  },
+  "0x0118:0x0311:0x0203": {
+    "description": "Double Relay Wall Switch",
+    "label": "TZ37",
+    "manufacturer": "TKB Home"
+  },
+  "0x0118:0x0311:0x0302": {
+    "description": "RGB dimmer switch",
+    "label": "TZ77",
+    "manufacturer": "TKB Home"
+  },
+  "0x0118:0x0311:0x0303": {
+    "description": "Rollershutter Controller",
+    "label": "TZ75",
+    "manufacturer": "TKB Home"
+  },
+  "0x0118:0x0311:0x0304": {
+    "description": "Insert two channel switch module",
+    "label": "TZ74",
+    "manufacturer": "TKB Home"
+  },
+  "0x0118:0x0311:0x0305": {
+    "description": "Insert switch module",
+    "label": "TZ79",
+    "manufacturer": "TKB Home"
+  },
+  "0x0118:0x0311:0x0505": {
+    "description": "Weekly Programming Thermostat with LCD Touch Screen",
+    "label": "TZE93",
+    "manufacturer": "TKB Home"
+  },
+  "0x0118:0x0311:0x0506": {
+    "description": "Color Touch Heating Thermostat",
+    "label": "TZE96",
+    "manufacturer": "TKB Home"
+  },
+  "0x0118:0x0808:0x0808": {
+    "description": "Single Paddle Wall Dimmer",
+    "label": "TZ55S",
+    "manufacturer": "TKB Home"
+  },
+  "0x0118:0x0b00:0x0002": {
+    "description": "Lifting Controller (Blinds Controller)",
+    "label": "GR308",
+    "manufacturer": "TKB Home"
+  },
+  "0x011a:0x0101:0x0102": {
+    "description": "Binary Switch",
+    "label": "ZW15S",
+    "manufacturer": "Wenzhou MTLC Electric Appliances Co., Ltd."
+  },
+  "0x011a:0x0101:0x0103": {
+    "description": "Duplex receptacle",
+    "label": "ZW15R",
+    "manufacturer": "Wenzhou MTLC Electric Appliances Co., Ltd."
+  },
+  "0x011a:0x0101:0x0104": {
+    "description": "Plug-in Appliance Module",
+    "label": "ZWN-333",
+    "manufacturer": "Wenzhou MTLC Electric Appliances Co., Ltd."
+  },
+  "0x011a:0x0101:0x0603": {
+    "description": "20A Tamper Resistant Duplex Receptacle",
+    "label": "ZW20R",
+    "manufacturer": "Wenzhou MTLC Electric Appliances Co., Ltd."
+  },
+  "0x011a:0x0101:0x5605": {
+    "description": "Smart Relay Switch Module",
+    "label": "ZWN-RSM1-PLUS",
+    "manufacturer": "Wenzhou MTLC Electric Appliances Co., Ltd."
+  },
+  "0x011a:0x0101:0x5606": {
+    "description": "Smart Dual Relay Switch Module",
+    "label": "ZWN-RSM1 / ZWN-RSM2",
+    "manufacturer": "Wenzhou MTLC Electric Appliances Co., Ltd."
+  },
+  "0x011a:0x0102:0x0201": {
+    "description": "Dimmer",
+    "label": "ZW500D",
+    "manufacturer": "Wenzhou MTLC Electric Appliances Co., Ltd."
+  },
+  "0x011a:0x0102:0x0202": {
+    "description": "Dimmer",
+    "label": "ZW500D",
+    "manufacturer": "Wenzhou MTLC Electric Appliances Co., Ltd."
+  },
+  "0x011a:0x0111:0x0101": {
+    "description": "In-wall Smart Meter Duplex Receptacle",
+    "label": "ZW20RM",
+    "manufacturer": "Wenzhou MTLC Electric Appliances Co., Ltd."
+  },
+  "0x011a:0x0111:0x0102": {
+    "description": "Binary Switch + Meter",
+    "label": "ZW15SM",
+    "manufacturer": "Wenzhou MTLC Electric Appliances Co., Ltd."
+  },
+  "0x011a:0x0111:0x0105": {
+    "description": "In-Wall Smart Meter Duplex Receptacle (15A)",
+    "label": "ZW15RM-PLUS",
+    "manufacturer": "Wenzhou MTLC Electric Appliances Co., Ltd."
+  },
+  "0x011a:0x0111:0x0201": {
+    "description": "In-wall Smart Meter Dimmer Switch",
+    "label": "ZW500DM",
+    "manufacturer": "Wenzhou MTLC Electric Appliances Co., Ltd."
+  },
+  "0x011a:0x0111:0x0202": {
+    "description": "ZWN323M",
+    "label": "Plug-In Smart Meter Dimmer Switch",
+    "manufacturer": "Wenzhou MTLC Electric Appliances Co., Ltd."
+  },
+  "0x011a:0x0111:0x0605": {
+    "description": "Smart Dual Relay Switch Module",
+    "label": "ZWN-RSM1 / ZWN-RSM2",
+    "manufacturer": "Wenzhou MTLC Electric Appliances Co., Ltd."
+  },
+  "0x011a:0x0111:0x0606": {
+    "description": "Smart Dual Relay Switch Module",
+    "label": "ZWN-RSM1 / ZWN-RSM2",
+    "manufacturer": "Wenzhou MTLC Electric Appliances Co., Ltd."
+  },
+  "0x011a:0x0601:0x0901": {
+    "description": "PIR Sensor",
+    "label": "ZWN-BPC-PLUS",
+    "manufacturer": "Wenzhou MTLC Electric Appliances Co., Ltd."
+  },
+  "0x011a:0x0601:0x0903": {
+    "description": "Magnetic Door/Window Sensor",
+    "label": "ZWN-BDS",
+    "manufacturer": "Wenzhou MTLC Electric Appliances Co., Ltd."
+  },
+  "0x011a:0x0801:0x0b03": {
+    "description": "Scene Controller",
+    "label": "ZWN-SC7",
+    "manufacturer": "Wenzhou MTLC Electric Appliances Co., Ltd."
+  },
+  "0x011a:0x1112:0x3040": {
+    "description": "ENERWAVE Z-WAVE Dimmer Switch",
+    "label": "ZW500",
+    "manufacturer": "Wenzhou MTLC Electric Appliances Co., Ltd."
+  },
+  "0x011a:0x1415:0x3343": {
+    "description": "Binary Switch",
+    "label": "ZW15S",
+    "manufacturer": "Wenzhou MTLC Electric Appliances Co., Ltd."
+  },
+  "0x011b:0x0001:0x0001": {
+    "description": "eedomus",
+    "label": "EEDOMUS+",
+    "manufacturer": "Connected Object"
+  },
+  "0x011f:0x0001:0x0001": {
+    "description": "Schlage PIR Motion Sensor",
+    "label": "PIR Motion Sensor",
+    "manufacturer": "Schlage"
+  },
+  "0x011f:0x0001:0x0002": {
+    "description": "Z-Wave Door/Window Sensor",
+    "label": "DWZWAVE1",
+    "manufacturer": "Schlage"
+  },
+  "0x011f:0x0001:0x0003": {
+    "description": "Tilt Sensor",
+    "label": "Tilt Sensor",
+    "manufacturer": "Schlage"
+  },
+  "0x0121:0x0001:0x0101": {
+    "description": "I-Bridge Z-Wave Controller",
+    "label": "IBR-ZREMOTE",
+    "manufacturer": "Napco Security Technologies, Inc."
+  },
+  "0x0122:0x0000:0x0000": {
+    "description": "Prodrive - ED2.0 Meter Adapter",
+    "label": "ED2.0 METER ADAPTER",
+    "manufacturer": "MSK - Miyakawa Seisakusho"
+  },
+  "0x0122:0x0001:0x0001": {
+    "description": "MSK CT type electric power measuring instrument",
+    "label": "ME-D101",
+    "manufacturer": "MSK - Miyakawa Seisakusho"
+  },
+  "0x0123:0x0001:0x0063": {
+    "description": "Iwatsu LED Dimmer",
+    "label": "LED Dimmer",
+    "manufacturer": "IWATSU"
+  },
+  "0x0123:0x0002:0x0000": {
+    "description": "Iwatsu",
+    "label": "NE-1LCNT",
+    "manufacturer": "IWATSU"
+  },
+  "0x0123:0x0102:0x0102": {
+    "description": "Iwatsu Smart Connect",
+    "label": "Smart Connect",
+    "manufacturer": "IWATSU"
+  },
+  "0x0123:0x0103:0x0103": {
+    "description": "Iwatsu Smart Connect",
+    "label": "Smart Connect",
+    "manufacturer": "IWATSU"
+  },
+  "0x0123:0x0104:0x0104": {
+    "description": "Iwatsu",
+    "label": "PMD35D",
+    "manufacturer": "IWATSU"
+  },
+  "0x0123:0x0301:0x0027": {
+    "description": "Iwatsu Motion Sensor",
+    "label": "Motion Sensor",
+    "manufacturer": "IWATSU"
+  },
+  "0x0123:0x0601:0x0027": {
+    "description": "Iwatsu Illumination Sensor",
+    "label": "Illumination Sensor",
+    "manufacturer": "IWATSU"
+  },
+  "0x0123:0x0a01:0x0001": {
+    "description": "Z-Wave Extender for Smoke Detection Sensor",
+    "label": "NE-SSEN",
+    "manufacturer": "IWATSU"
+  },
+  "0x0123:0x8000:0x0000": {
+    "description": "Iwatsu",
+    "label": "PMD35D",
+    "manufacturer": "IWATSU"
+  },
+  "0x0123:0x8001:0x0001": {
+    "description": "Smart-BRIDGE CL",
+    "label": "SMART-BRIDGE CL",
+    "manufacturer": "IWATSU"
+  },
+  "0x0123:0x8001:0x0002": {
+    "description": "Smart-BRIDGE C3",
+    "label": "SMART-BRIDGE C3",
+    "manufacturer": "IWATSU"
+  },
+  "0x0125:0x0001:0x0001": {
+    "description": "Z-Wave Native Tubular Motor",
+    "label": "ZWUS-5",
+    "manufacturer": "Motion Control Systems"
+  },
+  "0x0126:0x0001:0x0006": {
+    "description": "Jupiter Hub",
+    "label": "HUB520",
+    "manufacturer": "Alertme"
+  },
+  "0x0127:0x0738:0x0001": {
+    "description": "738Zplus",
+    "label": "738ZPL",
+    "manufacturer": "DMP (Digital Monitoring Products)"
+  },
+  "0x0127:0x0738:0x0002": {
+    "description": "XTLplus",
+    "label": "XTLPL",
+    "manufacturer": "DMP (Digital Monitoring Products)"
+  },
+  "0x0128:0x0000:0x0000": {
+    "description": "Eneco Meter Adapter",
+    "label": "ED2.0",
+    "manufacturer": "Prodrive Technologies"
+  },
+  "0x0129:0x0000:0x2132": {
+    "description": "Real Living Touchscreen Lever Lock",
+    "label": "YRL210 / YRL220",
+    "manufacturer": "Yale"
+  },
+  "0x0129:0x0001:0x0000": {
+    "description": "Real Living Touchscreen Lever Lock",
+    "label": "YRL210 / YRL220",
+    "manufacturer": "Yale"
+  },
+  "0x0129:0x0001:0x0409": {
+    "description": "Real Living Touchscreen Lever Lock",
+    "label": "YRL210 / YRL220",
+    "manufacturer": "Yale"
+  },
+  "0x0129:0x0002:0x0000": {
+    "description": "Real Living Touchscreen Deadbolt",
+    "label": "YRD220 / YRD240",
+    "manufacturer": "Yale"
+  },
+  "0x0129:0x0002:0x0209": {
+    "description": "Real Living Touchscreen Deadbolt",
+    "label": "YRD220 / YRD240",
+    "manufacturer": "Yale"
+  },
+  "0x0129:0x0002:0x0800": {
+    "description": "Key-Free Touchscreen Deadbolt",
+    "label": "YRD120",
+    "manufacturer": "Yale"
+  },
+  "0x0129:0x0002:0xaa00": {
+    "description": "Real Living Touchscreen Deadbolt",
+    "label": "YRD220 / YRD240",
+    "manufacturer": "Yale"
+  },
+  "0x0129:0x0002:0xffff": {
+    "description": "Real Living Touchscreen Deadbolt",
+    "label": "YRD220 / YRD240",
+    "manufacturer": "Yale"
+  },
+  "0x0129:0x0003:0x0409": {
+    "description": "Push Button Lever Lock",
+    "label": "YRL210",
+    "manufacturer": "Yale"
+  },
+  "0x0129:0x0004:0x0000": {
+    "description": "Push Button Deadbolt",
+    "label": "YRD210",
+    "manufacturer": "Yale"
+  },
+  "0x0129:0x0004:0x0209": {
+    "description": "Push Button Deadbolt",
+    "label": "YRD210",
+    "manufacturer": "Yale"
+  },
+  "0x0129:0x0004:0x0800": {
+    "description": "Key-Free Push-Button Deadbolt",
+    "label": "YRD110",
+    "manufacturer": "Yale"
+  },
+  "0x0129:0x0004:0xaa00": {
+    "description": "Push Button Deadbolt",
+    "label": "YRD210",
+    "manufacturer": "Yale"
+  },
+  "0x0129:0x0006:0x0000": {
+    "description": "Smart Living Keyfree Smart Lock",
+    "label": "YDM3109 / YDM4109",
+    "manufacturer": "Yale"
+  },
+  "0x0129:0x0006:0x0001": {
+    "description": "Keyfree Connected Lock",
+    "label": "YKFCON",
+    "manufacturer": "Yale"
+  },
+  "0x0129:0x0007:0x0000": {
+    "description": "Smart Door Lock",
+    "label": "P-KFCON-MOD-YALE",
+    "manufacturer": "Yale"
+  },
+  "0x0129:0x0007:0x0001": {
+    "description": "Smart Door Lock",
+    "label": "P-KFCON-MOD-YALE",
+    "manufacturer": "Yale"
+  },
+  "0x0129:0x0008:0x0000": {
+    "description": "Smart Door Lock",
+    "label": "06-0001-0000-00-0011-Z",
+    "manufacturer": "ASSA ABLOY"
+  },
+  "0x0129:0x0040:0x0000": {
+    "description": "Digital Door Lock",
+    "label": "YDM3168",
+    "manufacturer": "Yale"
+  },
+  "0x0129:0x0066:0x0000": {
+    "description": "Conexis L1",
+    "label": "SD-L1000-CH",
+    "manufacturer": "Yale"
+  },
+  "0x0129:0x2022:0x0209": {
+    "description": "Real Living Touchscreen Deadbolt",
+    "label": "YRD220 / YRD240",
+    "manufacturer": "Yale"
+  },
+  "0x0129:0x6600:0x0002": {
+    "description": "Conexis L1",
+    "label": "SD-L1000-CH",
+    "manufacturer": "Yale"
+  },
+  "0x0129:0x6f01:0x0001": {
+    "description": "External siren",
+    "label": "SR-BX-ZW",
+    "manufacturer": "Yale"
+  },
+  "0x0129:0x8001:0x0b00": {
+    "description": "NexTouch Wireless Push Button with Z-Wave",
+    "label": "NTB610",
+    "manufacturer": "Yale"
+  },
+  "0x0129:0x8002:0x0600": {
+    "description": "Assure Touchscreen Deadbolt",
+    "label": "YRD226 / YRC226 / YRC246 / YRD256 / YRC256 / YRD446",
+    "manufacturer": "Yale"
+  },
+  "0x0129:0x8002:0x1000": {
+    "description": "Real Living Assure Lock with Z-Wave and Bluetooth",
+    "label": "YRD426-ZW2",
+    "manufacturer": "Yale"
+  },
+  "0x0129:0x8002:0x4600": {
+    "description": "Assure Touchscreen Deadbolt",
+    "label": "YRD226 / YRC226 / YRC246 / YRD256 / YRC256 / YRD446",
+    "manufacturer": "Yale"
+  },
+  "0x0129:0x8002:0x46d5": {
+    "description": "Assure SL Lock",
+    "label": "YRD256-ZW3",
+    "manufacturer": "Yale"
+  },
+  "0x0129:0x8002:0xa570": {
+    "description": "Assure SL Lock",
+    "label": "YRD256-ZW3",
+    "manufacturer": "Yale"
+  },
+  "0x0129:0x8003:0x0b00": {
+    "description": "NexTouch Wireless Touchscreen with Z-Wave",
+    "label": "NTB620",
+    "manufacturer": "Yale"
+  },
+  "0x0129:0x8004:0x0600": {
+    "description": "Real Living Assure Lock Push Button Deadbolt",
+    "label": "YRD216 / YRC216",
+    "manufacturer": "Yale"
+  },
+  "0x0129:0x8004:0x1000": {
+    "description": "Assure Lock with Bluetooth Z-Wave Enabled Push Button Deadbolt",
+    "label": "YRD416",
+    "manufacturer": "Yale"
+  },
+  "0x0129:0x8007:0x0a00": {
+    "description": "NexTouch Sectional Mortise Push Button Keypad Lock with cylinder with deadbolt",
+    "label": "NTM610 / NTM615 / NTM630 / NTM625",
+    "manufacturer": "Yale"
+  },
+  "0x0129:0x8008:0x0a00": {
+    "description": "NexTouch Sectional Mortise Touch Screen Keypad Lock",
+    "label": "NTM620 / NTM625 / NTM640 / NTM645",
+    "manufacturer": "Yale"
+  },
+  "0x0129:0x8009:0x0c00": {
+    "description": "NexTouch Keypad Exit Rim Trim",
+    "label": "NTT610",
+    "manufacturer": "Yale"
+  },
+  "0x0129:0x800a:0x0c00": {
+    "description": "NexTouch Touchscreen Exit Rim Trim",
+    "label": "NTT620",
+    "manufacturer": "Yale"
+  },
+  "0x0129:0x800b:0x0f00": {
+    "description": "Assure Lever Keypad with Z-Wave Plus",
+    "label": "YRL216 / YRL236",
+    "manufacturer": "Yale"
+  },
+  "0x0129:0x800c:0x0f00": {
+    "description": "Assure Key Free Lever Touchscreen",
+    "label": "YRL226 / YRL256",
+    "manufacturer": "Yale"
+  },
+  "0x0129:0x800e:0x1200": {
+    "description": "Assure Lock Touchscreen Deadbolt",
+    "label": "YRD620 / YRC620",
+    "manufacturer": "Yale"
+  },
+  "0x0129:0x8014:0x1600": {
+    "description": "Assure Lock for Andersen Patio Doors",
+    "label": "YRM276",
+    "manufacturer": "Yale"
+  },
+  "0x0129:0x8014:0x1604": {
+    "description": "Assure Lock for Andersen Patio Doors",
+    "label": "YRM476",
+    "manufacturer": "Yale"
+  },
+  "0x0129:0x803a:0x0508": {
+    "description": "Touchscreen Deadbolt with Integrated ZWave Plus",
+    "label": "YRD156",
+    "manufacturer": "Yale"
+  },
+  "0x0129:0x803b:0x0508": {
+    "description": "ProSL Key Free Keypad Deadbolt with Z-Wave Plus",
+    "label": "YRD136",
+    "manufacturer": "Yale"
+  },
+  "0x0129:0x842a:0x3cac": {
+    "description": "Real Living Touchscreen Lever Lock",
+    "label": "YRL210 / YRL220",
+    "manufacturer": "Yale"
+  },
+  "0x0129:0xc600:0x0002": {
+    "description": "Smart Door Lock Z-Wave Module 2",
+    "label": "SD-M1100",
+    "manufacturer": "Yale"
+  },
+  "0x0129:0xc600:0x0300": {
+    "description": "Smart Door Lock",
+    "label": "YDM3109",
+    "manufacturer": "Yale"
+  },
+  "0x0129:0xc700:0x0005": {
+    "description": "Digital Door Lock",
+    "label": "YDM4109+",
+    "manufacturer": "Yale"
+  },
+  "0x012a:0x0001:0x0002": {
+    "description": "IQPanel2",
+    "label": "IQPanel2",
+    "manufacturer": "Qolsys"
+  },
+  "0x012a:0x0001:0x0003": {
+    "description": "IQ Panel 2+",
+    "label": "QS9201-1208-840",
+    "manufacturer": "Qolsys"
+  },
+  "0x012a:0x0002:0x0001": {
+    "description": "IQ Panel",
+    "label": "IQ Panel",
+    "manufacturer": "Qolsys"
+  },
+  "0x012a:0x4447:0x3031": {
+    "description": "IQ Outlet Plug-In On/Off Switch",
+    "label": "QZ2130-840",
+    "manufacturer": "Qolsys"
+  },
+  "0x012a:0x4744:0x3032": {
+    "description": "Z-Wave Plug-In Dimmer",
+    "label": "QZ2140-840",
+    "manufacturer": "Qolsys"
+  },
+  "0x0130:0x0001:0x0001": {
+    "description": "Quby Energy Display",
+    "label": "QB2",
+    "manufacturer": "Quby"
+  },
+  "0x0130:0x0001:0x0003": {
+    "description": "Display QB3",
+    "label": "QB3.X",
+    "manufacturer": "Quby"
+  },
+  "0x0130:0x0002:0x0001": {
+    "description": "Engie Meter Adapter",
+    "label": "EN00",
+    "manufacturer": "Quby"
+  },
+  "0x0131:0x0001:0x0001": {
+    "description": "Zipabox",
+    "label": "ZB.ZW.G",
+    "manufacturer": "Zipato"
+  },
+  "0x0131:0x0001:0x0002": {
+    "description": "Zipabox",
+    "label": "ZB.ZW.G",
+    "manufacturer": "Zipato"
+  },
+  "0x0131:0x0001:0x0003": {
+    "description": "Zipabox",
+    "label": "ZB.ZW.G",
+    "manufacturer": "Zipato"
+  },
+  "0x0131:0x0001:0x0012": {
+    "description": "In Wall Dual Relay",
+    "label": "PAN04",
+    "manufacturer": "Zipato"
+  },
+  "0x0131:0x0001:0x0015": {
+    "description": "roller shutter",
+    "label": "PAN08",
+    "manufacturer": "Zipato"
+  },
+  "0x0131:0x0002:0x0002": {
+    "description": "RGBW bulb",
+    "label": "RGBWE27ZW",
+    "manufacturer": "Zipato"
+  },
+  "0x0131:0x0002:0x0003": {
+    "description": "RGBW Bulb V2",
+    "label": "RGBWE2",
+    "manufacturer": "Zipato"
+  },
+  "0x0131:0x0002:0x000c": {
+    "description": "Door/temp/illumination/motion sensor",
+    "label": "PSP02",
+    "manufacturer": "Zipato"
+  },
+  "0x0131:0x0002:0x001e": {
+    "description": "Smoke Sensor",
+    "label": "PH-PSG01",
+    "manufacturer": "Zipato"
+  },
+  "0x0131:0x0003:0x0082": {
+    "description": "Door sensor",
+    "label": "NE-NAS-DS01Z",
+    "manufacturer": "Zipato"
+  },
+  "0x0131:0x0003:0x0512": {
+    "description": "Auto Valve",
+    "label": "GR-105",
+    "manufacturer": "Zipato"
+  },
+  "0x0131:0x0003:0x1082": {
+    "description": "Door/Window Sensor",
+    "label": "0131",
+    "manufacturer": "Zipato"
+  },
+  "0x0131:0x0003:0x1083": {
+    "description": "Indoor Siren",
+    "label": "NE-NAS-AB02Z",
+    "manufacturer": "Zipato"
+  },
+  "0x0131:0x0003:0x1089": {
+    "description": "PIR motion sensor and light measurement",
+    "label": "NE-NAS-PD01Z",
+    "manufacturer": "Zipato"
+  },
+  "0x0131:0x0006:0x001a": {
+    "description": "Micro Module Energy Meter",
+    "label": "ZIP-PAB01",
+    "manufacturer": "Zipato"
+  },
+  "0x0131:0x0033:0x1082": {
+    "description": "Door sensor",
+    "label": "NE-NAS-DS01Z",
+    "manufacturer": "Zipato"
+  },
+  "0x0131:0x2001:0x0106": {
+    "description": "Door Window Sensor",
+    "label": "ZD2102-5",
+    "manufacturer": "Zipato"
+  },
+  "0x0131:0x2002:0x0205": {
+    "description": "Multi Sensor Dual: motion and temperature sensor",
+    "label": "ZP3102",
+    "manufacturer": "Zipato"
+  },
+  "0x0131:0x201f:0x1f20": {
+    "description": "Zipato 4 in 1 Door Sensor",
+    "label": "VS-ZD2301",
+    "manufacturer": "Zipato"
+  },
+  "0x0131:0x220a:0x1352": {
+    "description": "MINI ENERGY DIMMER",
+    "label": "MH-P220",
+    "manufacturer": "Zipato"
+  },
+  "0x0131:0x8002:0x1000": {
+    "description": "Smoke Detector",
+    "label": "HS1SA",
+    "manufacturer": "Zipato"
+  },
+  "0x0131:0x8003:0x1000": {
+    "description": "Combustible Gas Sensor",
+    "label": "HM-HS1CG-Z",
+    "manufacturer": "Zipato"
+  },
+  "0x0131:0x8004:0x1000": {
+    "description": "Smart Water Leakage Sensor",
+    "label": "HM-HS1WL-Z",
+    "manufacturer": "Zipato"
+  },
+  "0x0131:0x8005:0x1000": {
+    "description": "CO Sensor with acoustic alarm",
+    "label": "HM-HS1CA",
+    "manufacturer": "Zipato"
+  },
+  "0x0133:0x0001:0x0001": {
+    "description": "Home Automation and Control Unit",
+    "label": "PGZNG1-2ADNAS",
+    "manufacturer": "Netgear"
+  },
+  "0x0135:0x0000:0x0001": {
+    "description": "Smoke Sensor",
+    "label": "SHD1115",
+    "manufacturer": "ZyXEL"
+  },
+  "0x0135:0x0002:0x0001": {
+    "description": "Door-Window Sensor",
+    "label": "SHD 1111",
+    "manufacturer": "ZyXEL"
+  },
+  "0x0135:0x0003:0x0001": {
+    "description": "Dimmer Module",
+    "label": "SHD2210",
+    "manufacturer": "ZyXEL"
+  },
+  "0x0135:0x0004:0x0001": {
+    "description": "Plug-in On/Off Module",
+    "label": "SHD2110",
+    "manufacturer": "ZyXEL"
+  },
+  "0x0135:0x0004:0x0002": {
+    "description": "On/Off Plug with Metering",
+    "label": "SHD3110",
+    "manufacturer": "ZyXEL"
+  },
+  "0x0135:0x0006:0x0001": {
+    "description": "Temperature/Humidity Sensor",
+    "label": "SHD1110",
+    "manufacturer": "ZyXEL"
+  },
+  "0x0135:0x000b:0x0001": {
+    "description": "Flood sensor",
+    "label": "ST812",
+    "manufacturer": "ZyXEL"
+  },
+  "0x0135:0x0101:0x0001": {
+    "description": "PIR Sensor",
+    "label": "SHD 1112",
+    "manufacturer": "ZyXEL"
+  },
+  "0x0136:0x0001:0x0001": {
+    "description": "SysLINK M2M Gateway",
+    "label": "SL-1500",
+    "manufacturer": "Systech Corporation"
+  },
+  "0x0137:0x1001:0x0001": {
+    "description": "FollowGood - Fingerprint Door Lock",
+    "label": "ELK-1001",
+    "manufacturer": "FollowGood Technology Company Ltd."
+  },
+  "0x0137:0x2001:0x0001": {
+    "description": "Gateway",
+    "label": "PU-1000",
+    "manufacturer": "FollowGood Technology Company Ltd."
+  },
+  "0x0137:0x3001:0x0002": {
+    "description": "Power Switch",
+    "label": "SWZ-1002",
+    "manufacturer": "FollowGood Technology Company Ltd."
+  },
+  "0x0138:0x0001:0x0001": {
+    "description": "Smoke Alarm",
+    "label": "ZSMOKE",
+    "manufacturer": "BRK Brands, Inc."
+  },
+  "0x0138:0x0001:0x0002": {
+    "description": "Smoke and Carbon Monoxide Alarm",
+    "label": "ZCOMBO",
+    "manufacturer": "BRK Brands, Inc."
+  },
+  "0x0138:0x0001:0x0003": {
+    "description": "ZCombo-G Smoke/CO Alarm",
+    "label": "ZCOMBO",
+    "manufacturer": "First Alert (BRK Brands Inc)"
+  },
+  "0x0138:0x000c:0x0001": {
+    "description": "Smoke and Carbon Monoxide Alarm",
+    "label": "ZCOMBO",
+    "manufacturer": "BRK Brands, Inc."
+  },
+  "0x0139:0x0444:0x0415": {
+    "description": "ZHOME Combo Switch",
+    "label": "AZ2R1",
+    "manufacturer": "KlickH Pvt Ltd."
+  },
+  "0x013b:0x1000:0x1828": {
+    "description": "Astralink Android Home Station",
+    "label": "HXS1000",
+    "manufacturer": "AstraLink"
+  },
+  "0x013c:0x0001:0x0000": {
+    "description": "Smart Energy Plug In Switch",
+    "label": "PAN16",
+    "manufacturer": "Philio Technology Corp"
+  },
+  "0x013c:0x0001:0x0001": {
+    "description": "Smart Energy Plug In Switch",
+    "label": "PAN11",
+    "manufacturer": "Philio Technology Corp"
+  },
+  "0x013c:0x0001:0x0003": {
+    "description": "In Wall Dual Relay(1 Way) Switch Module 2x 1.5kW with power meter",
+    "label": "PAN04",
+    "manufacturer": "Philio Technology Corp"
+  },
+  "0x013c:0x0001:0x0004": {
+    "description": "In Wall Dual Relay (1 Way) Switch Module 2 x 1.5kW",
+    "label": "PAN06",
+    "manufacturer": "Philio Technology Corp"
+  },
+  "0x013c:0x0001:0x0005": {
+    "description": "TWO SPDT Switch module with meter",
+    "label": "Philio PAN07-1A",
+    "manufacturer": "Philio Technology Corp"
+  },
+  "0x013c:0x0001:0x0006": {
+    "description": "Relay Insert for Blind Control",
+    "label": "PAN08",
+    "manufacturer": "Philio Technology Corp"
+  },
+  "0x013c:0x0001:0x000f": {
+    "description": "In Wall Micromodule Single Switch",
+    "label": "PAN03",
+    "manufacturer": "Philio Technology Corp"
+  },
+  "0x013c:0x0001:0x0010": {
+    "description": "Single relay in-wall switch module",
+    "label": "PAN05-1B",
+    "manufacturer": "Philio Technology Corp"
+  },
+  "0x013c:0x0001:0x0011": {
+    "description": "Smart Energy Plug In Switch",
+    "label": "PAN11",
+    "manufacturer": "Philio Technology Corp"
+  },
+  "0x013c:0x0001:0x0012": {
+    "description": "In Wall Dual Relay(1 Way) Switch Module 2x 1.5kW with power meter",
+    "label": "PAN04",
+    "manufacturer": "Philio Technology Corp"
+  },
+  "0x013c:0x0001:0x0013": {
+    "description": "In Wall Dual Relay (1 Way) Switch Module 2 x 1.5kW",
+    "label": "PAN06",
+    "manufacturer": "Philio Technology Corp"
+  },
+  "0x013c:0x0001:0x0014": {
+    "description": "In Wall Dual Relay(1 Way) Switch Module 2x 1.5kW with power meter",
+    "label": "PAN04",
+    "manufacturer": "Philio Technology Corp"
+  },
+  "0x013c:0x0001:0x0015": {
+    "description": "Roller shutter controller",
+    "label": "PAN08-1a",
+    "manufacturer": "Philio Technology Corp"
+  },
+  "0x013c:0x0001:0x0029": {
+    "description": "Smart Energy Plug In Switch",
+    "label": "PAN16",
+    "manufacturer": "Philio Technology Corp"
+  },
+  "0x013c:0x0001:0x0030": {
+    "description": "Smart Energy Plug In Switch",
+    "label": "PAN11",
+    "manufacturer": "Philio Technology Corp"
+  },
+  "0x013c:0x0001:0x0038": {
+    "description": "Smart Energy plug In switch",
+    "label": "PAN15-1-NES",
+    "manufacturer": "Philio Technology Corp"
+  },
+  "0x013c:0x0001:0x0061": {
+    "description": "In Wall Dual Relay(1 Way) Switch Module 2x 1.5kW with power meter",
+    "label": "PAN04",
+    "manufacturer": "Philio Technology Corp"
+  },
+  "0x013c:0x0001:0x0073": {
+    "description": "Smart Switch Box",
+    "label": "PAN26",
+    "manufacturer": "Philio Technology Corp"
+  },
+  "0x013c:0x0002:0x0002": {
+    "description": "Slim Multi-Sensor",
+    "label": "PSM02",
+    "manufacturer": "Philio Technology Corp"
+  },
+  "0x013c:0x0002:0x000c": {
+    "description": "Slim Multi-Sensor (PIR/Door/Temperature/Illumination)",
+    "label": "PST02A",
+    "manufacturer": "Philio Technology Corp"
+  },
+  "0x013c:0x0002:0x000d": {
+    "description": "Slim Multi-Sensor (PIR/Temperature/Illumination)",
+    "label": "PST02B",
+    "manufacturer": "Philio Technology Corp"
+  },
+  "0x013c:0x0002:0x000e": {
+    "description": "Slim Multi-Sensor (Door/Temperature/Illumination)",
+    "label": "PST02C",
+    "manufacturer": "Philio Technology Corp"
+  },
+  "0x013c:0x0002:0x001e": {
+    "description": "Daaf Zipato Smoke Sensor",
+    "label": "ZIPATO ZIP-PSG01",
+    "manufacturer": "Philio Technology Corp"
+  },
+  "0x013c:0x0002:0x001f": {
+    "description": "Flood Sensor",
+    "label": "PAT02-A",
+    "manufacturer": "Philio Technology Corp"
+  },
+  "0x013c:0x0002:0x0020": {
+    "description": "Z-Wave room sensor",
+    "label": "PAT02-B",
+    "manufacturer": "Philio Technology Corp"
+  },
+  "0x013c:0x0002:0x0021": {
+    "description": "Flood Sensor",
+    "label": "PAT02-C",
+    "manufacturer": "Philio Technology Corp"
+  },
+  "0x013c:0x0002:0x0036": {
+    "description": "Single Function Magnetic Sensor",
+    "label": "PSM08",
+    "manufacturer": "Philio Technology Corp"
+  },
+  "0x013c:0x0002:0x0050": {
+    "description": "Motion Sensor",
+    "label": "PSP05",
+    "manufacturer": "Philio Technology Corp"
+  },
+  "0x013c:0x0002:0x0059": {
+    "description": "Slim Multisensor",
+    "label": "PST02-A-BR",
+    "manufacturer": "Philio Technology Corp"
+  },
+  "0x013c:0x0002:0x006a": {
+    "description": "Recessed Door Sensor",
+    "label": "PSM09",
+    "manufacturer": "Philio Technology Corp"
+  },
+  "0x013c:0x0002:0x0071": {
+    "description": "Z-Wave CO Sensor",
+    "label": "PSG04",
+    "manufacturer": "Philio Technology Corp"
+  },
+  "0x013c:0x0003:0x0054": {
+    "description": "Control Center Gateway",
+    "label": "PSC03",
+    "manufacturer": "Philio Technology Corp"
+  },
+  "0x013c:0x0004:0x000a": {
+    "description": "Siren",
+    "label": "PSE02",
+    "manufacturer": "Philio Technology Corp"
+  },
+  "0x013c:0x0005:0x0031": {
+    "description": "Dimmer Socket",
+    "label": "PAD02",
+    "manufacturer": "Philio Technology Corp"
+  },
+  "0x013c:0x0005:0x0051": {
+    "description": "In Wall Smart Dimmer",
+    "label": "PAD07",
+    "manufacturer": "Philio Technology Corp"
+  },
+  "0x013c:0x0005:0x0060": {
+    "description": "Smart Dimmer Plug",
+    "label": "PAD09",
+    "manufacturer": "Philio Technology Corp"
+  },
+  "0x013c:0x0005:0x007e": {
+    "description": "2 Wire Dimmer",
+    "label": "PAD15",
+    "manufacturer": "Philio Technology Corp"
+  },
+  "0x013c:0x0006:0x001a": {
+    "description": "Zipato Micromodule Energy Meter",
+    "label": "ZIP-PAB01",
+    "manufacturer": "Philio Technology Corp"
+  },
+  "0x013c:0x0008:0x001d": {
+    "description": "Z-WAVE Remote",
+    "label": "PH-PSR03",
+    "manufacturer": "Philio Technology Corp"
+  },
+  "0x013c:0x0009:0x0022": {
+    "description": "Smart Color Button",
+    "label": "PSR04",
+    "manufacturer": "Philio Technology Corp"
+  },
+  "0x013c:0x0009:0x0039": {
+    "description": "Smart Color Button",
+    "label": "PSR07",
+    "manufacturer": "Philio Technology Corp"
+  },
+  "0x013c:0x000a:0x0069": {
+    "description": "DoorLock",
+    "label": "PSA03-US",
+    "manufacturer": "Philio Technology Corp"
+  },
+  "0x013c:0x000b:0x0058": {
+    "description": "Z-Wave JEM-A Adapter",
+    "label": "PAC01",
+    "manufacturer": "Philio Technology Corp"
+  },
+  "0x013c:0x000c:0x0074": {
+    "description": "Z-Wave Range Extender Repeater",
+    "label": "PAU05",
+    "manufacturer": "Philio Technology Corp"
+  },
+  "0x013c:0x1002:0x0202": {
+    "description": "4 Button Key Fob",
+    "label": "ZT1101",
+    "manufacturer": "Philio Technology Corp"
+  },
+  "0x0140:0x0801:0x1001": {
+    "description": "Window Sensor Fensterkontakt Z-Wave",
+    "label": "FKABZ002",
+    "manufacturer": "Computime"
+  },
+  "0x0144:0x0000:0x0000": {
+    "description": "AME Qbox",
+    "label": "6618-1200-2306",
+    "manufacturer": "Applied Micro Electronics \"AME\" BV"
+  },
+  "0x0145:0x0001:0x0004": {
+    "description": "Buffalo",
+    "label": "HW-100V15A-ZW",
+    "manufacturer": "Buffalo Inc."
+  },
+  "0x0145:0x0002:0x0002": {
+    "description": "Buffalo Switch",
+    "label": "TM-H2VHA081",
+    "manufacturer": "Buffalo Inc."
+  },
+  "0x0146:0x0001:0x0001": {
+    "description": "Axesstel Alert System",
+    "label": "AX140",
+    "manufacturer": "Axesstel Inc"
+  },
+  "0x0147:0x0002:0x0003": {
+    "description": "Z-Wave daughtercard",
+    "label": "RaZberry",
+    "manufacturer": "Z-Wave.me"
+  },
+  "0x0147:0x0400:0x0001": {
+    "description": "Z-Wave.Me Razberry daughtercard",
+    "label": "RaZberry Controller 2016 ZWave+",
+    "manufacturer": "Z-Wave.me"
+  },
+  "0x0147:0x0400:0x0002": {
+    "description": "Z-Wave.Me Razberry daughtercard",
+    "label": "RaZberry Controller 2016 ZWave+",
+    "manufacturer": "Z-Wave.me"
+  },
+  "0x0148:0x0001:0x0001": {
+    "description": "Thermostatic Valve",
+    "label": "STELLA Z",
+    "manufacturer": "Eurotronics"
+  },
+  "0x0148:0x0002:0x0001": {
+    "description": "Thermostatic Valve",
+    "label": "COMET Z",
+    "manufacturer": "Eurotronics"
+  },
+  "0x0148:0x0003:0x0001": {
+    "description": "Thermostatic Valve",
+    "label": "Spirit",
+    "manufacturer": "Eurotronics"
+  },
+  "0x0148:0x0003:0x0003": {
+    "description": "Thermostatic Valve",
+    "label": "Spirit",
+    "manufacturer": "Eurotronics"
+  },
+  "0x0148:0x0005:0x0001": {
+    "description": "Air Quality Sensor",
+    "label": "EUR_AIRQUALITY",
+    "manufacturer": "EUROtronic"
+  },
+  "0x0148:0x4672:0xbd41": {
+    "description": "Thermostatic Valve",
+    "label": "COMET Z",
+    "manufacturer": "Eurotronics"
+  },
+  "0x0149:0x0012:0x0104": {
+    "description": "WiDom Universal Relay Switch",
+    "label": "UBS104",
+    "manufacturer": "wiDom"
+  },
+  "0x0149:0x0014:0x0204": {
+    "description": "wiDom Universal Roller Shutter",
+    "label": "UMS1.04",
+    "manufacturer": "wiDom"
+  },
+  "0x0149:0x1214:0x0304": {
+    "description": "Energy Driven Switch",
+    "label": "WPS104",
+    "manufacturer": "wiDom"
+  },
+  "0x0149:0x1214:0x0504": {
+    "description": "Universal Double Switch",
+    "label": "WDS",
+    "manufacturer": "wiDom"
+  },
+  "0x0149:0x1214:0x0600": {
+    "description": "WiDom MultiSensor Room Controller",
+    "label": "WMSR",
+    "manufacturer": "wiDom"
+  },
+  "0x0149:0x1214:0x0700": {
+    "description": "Widom Smart Plug",
+    "label": "WSP1",
+    "manufacturer": "wiDom"
+  },
+  "0x0149:0x1214:0x0800": {
+    "description": "WiDom Smart Roller Shutter",
+    "label": "UMS2",
+    "manufacturer": "wiDom"
+  },
+  "0x0149:0x1214:0x0900": {
+    "description": "Widom Smart Dry contact",
+    "label": "DRY",
+    "manufacturer": "wiDom"
+  },
+  "0x0149:0x1214:0x0a00": {
+    "description": "Widom Smart Dimmer",
+    "label": "WTE",
+    "manufacturer": "wiDom"
+  },
+  "0x0149:0x1214:0x0b00": {
+    "description": "Widom Smart Double Switch",
+    "label": "WDS2",
+    "manufacturer": "wiDom"
+  },
+  "0x0149:0x1214:0x0c00": {
+    "description": "Widom Smart Double Switch",
+    "label": "WDS2",
+    "manufacturer": "wiDom"
+  },
+  "0x014a:0x0001:0x0001": {
+    "description": "Z-Wave PIR Motion Sensor",
+    "label": "PIRZWAVE1",
+    "manufacturer": "Ecolink"
+  },
+  "0x014a:0x0001:0x0002": {
+    "description": "Z-Wave Door/Window Sensor",
+    "label": "DWZWAVE2",
+    "manufacturer": "Ecolink"
+  },
+  "0x014a:0x0001:0x0003": {
+    "description": "Z-Wave Garage Door Sensor",
+    "label": "TILTZWAVE1",
+    "manufacturer": "Ecolink"
+  },
+  "0x014a:0x0004:0x0001": {
+    "description": "Z-Wave Motion Sensor",
+    "label": "PIR Motion Sensor v2.5",
+    "manufacturer": "Ecolink"
+  },
+  "0x014a:0x0004:0x0002": {
+    "description": "Z-Wave Door/Window Sensor",
+    "label": "DWZWAVE25",
+    "manufacturer": "Ecolink"
+  },
+  "0x014a:0x0004:0x0003": {
+    "description": "Z-wave Plus Gold Plated Reliability Garage Door Tilt Sensor",
+    "label": "TILT-ZWAVE2.5-ECO",
+    "manufacturer": "Ecolink"
+  },
+  "0x014a:0x0005:0x000a": {
+    "description": "Ecolink Z-Wave Plus Wireless Siren",
+    "label": "SC-ZWAVE5",
+    "manufacturer": "Ecolink"
+  },
+  "0x014a:0x0005:0x000f": {
+    "description": "Ecolink Z-Wave Plus FireFighter",
+    "label": "FF-ZWAVE5-ECO",
+    "manufacturer": "Ecolink"
+  },
+  "0x014a:0x0005:0x0010": {
+    "description": "Z-Wave Wireless Flood/Freeze Sensor",
+    "label": "H214104",
+    "manufacturer": "Ecolink"
+  },
+  "0x014a:0x0006:0x0001": {
+    "description": "Z-Wave Plus Single Gang Decora Wireless Light Switch",
+    "label": "DLS-ZWAVE5",
+    "manufacturer": "Ecolink"
+  },
+  "0x014a:0x0006:0x0002": {
+    "description": "Automated Light Switch",
+    "label": "TLS-ZWAVE5",
+    "manufacturer": "Ecolink"
+  },
+  "0x014a:0x0006:0x0003": {
+    "description": "Z-Wave Plus Smart Switch - Double Rocker",
+    "label": "DDLS2-ZWAVE5",
+    "manufacturer": "Ecolink"
+  },
+  "0x014a:0x0006:0x0004": {
+    "description": "Z-Wave Plus Smart Switch - Double Toggle",
+    "label": "DTLS2-ZWAVE5",
+    "manufacturer": "Ecolink"
+  },
+  "0x014a:0x0006:0x0005": {
+    "description": "Z-Wave Plus Smart Switch - Single Rocker",
+    "label": "SDLS2-ZWAVE5",
+    "manufacturer": "Ecolink"
+  },
+  "0x014a:0x0006:0x0006": {
+    "description": "Z-Wave Plus Smart Switch - SingleToggle",
+    "label": "STLS2-ZWAVE5",
+    "manufacturer": "Ecolink"
+  },
+  "0x014a:0x0007:0x3975": {
+    "description": "Chime+Siren",
+    "label": "ISZW7-ECO",
+    "manufacturer": "Ecolink"
+  },
+  "0x014a:0x014a:0x0000": {
+    "description": "",
+    "label": "Z-Wave Garage Door Tilt Sensor",
+    "manufacturer": "Ecolink"
+  },
+  "0x014d:0x0001:0x0001": {
+    "description": "USB Dongle",
+    "label": "SS201-US-W_1308",
+    "manufacturer": "Enblink Co. Ltd."
+  },
+  "0x014d:0x0001:0x0002": {
+    "description": "",
+    "label": "DKC1000",
+    "manufacturer": "Enblink Co. Ltd."
+  },
+  "0x014d:0x0001:0x0004": {
+    "description": "",
+    "label": "DKC1001",
+    "manufacturer": "Enblink Co. Ltd."
+  },
+  "0x014d:0x0001:0x0302": {
+    "description": "",
+    "label": "SS302",
+    "manufacturer": "Enblink Co. Ltd."
+  },
+  "0x014d:0x0002:0x0302": {
+    "description": "",
+    "label": "SS302",
+    "manufacturer": "Enblink Co. Ltd."
+  },
+  "0x014d:0x0003:0x0302": {
+    "description": "",
+    "label": "SS302",
+    "manufacturer": "Enblink Co. Ltd."
+  },
+  "0x014d:0x0054:0x0001": {
+    "description": "Smart Button",
+    "label": "IBDK-01",
+    "manufacturer": "Enblink Co. Ltd."
+  },
+  "0x014f:0x0000:0x0000": {
+    "description": "SmartStick+",
+    "label": "HUSBZ",
+    "manufacturer": "Nortek Security & Control LLC"
+  },
+  "0x014f:0x0601:0x0901": {
+    "description": "PIR Sensor",
+    "label": "ZWN-BPC",
+    "manufacturer": "Nortek Security & Control LLC"
+  },
+  "0x014f:0x1000:0x1001": {
+    "description": "2GIG GC2e Wireless Security & Automation System",
+    "label": "2GIG-GC2",
+    "manufacturer": "Nortek Security & Control LLC"
+  },
+  "0x014f:0x2001:0x0102": {
+    "description": "Door/Windows Sensor",
+    "label": "WADWAZ-1",
+    "manufacturer": "Nortek Security & Control LLC"
+  },
+  "0x014f:0x2002:0x0203": {
+    "description": "PIR Motion Detector",
+    "label": "WAPIRZ-1",
+    "manufacturer": "Nortek Security & Control LLC"
+  },
+  "0x014f:0x2005:0x0503": {
+    "description": "Siren and Strobe",
+    "label": "WA105DBZ",
+    "manufacturer": "Nortek Security & Control LLC"
+  },
+  "0x014f:0x2005:0x0508": {
+    "description": "Battery Operated Siren",
+    "label": "ZM1601",
+    "manufacturer": "Nortek Security & Control LLC"
+  },
+  "0x014f:0x2009:0x0903": {
+    "description": "Siren and Strobe",
+    "label": "WA105DBZ",
+    "manufacturer": "Nortek Security & Control LLC"
+  },
+  "0x014f:0x201c:0x1c03": {
+    "description": "Smart Water Leak Sensor",
+    "label": "WF00Z",
+    "manufacturer": "Nortek Security & Control LLC"
+  },
+  "0x014f:0x4153:0x3031": {
+    "description": "ADT Security Hub",
+    "label": "Security Hub",
+    "manufacturer": "ADT"
+  },
+  "0x014f:0x4450:0x3030": {
+    "description": "Plug-in Wall Dimmer",
+    "label": "PD300Z-2",
+    "manufacturer": "Nortek Security & Control LLC"
+  },
+  "0x014f:0x4457:0x3034": {
+    "description": "Wall Dimmer Switch",
+    "label": "WD500Z-1",
+    "manufacturer": "Nortek Security & Control LLC"
+  },
+  "0x014f:0x4742:0x3030": {
+    "description": "Glass Break Detector",
+    "label": "GB00Z",
+    "manufacturer": "Nortek Security & Control LLC"
+  },
+  "0x014f:0x4744:0x3030": {
+    "description": "Garage Door Controller",
+    "label": "NGD00Z-4",
+    "manufacturer": "Nortek Security & Control LLC"
+  },
+  "0x014f:0x4744:0x3032": {
+    "description": "Garage Door Controller",
+    "label": "NGD00Z-4",
+    "manufacturer": "Nortek Security & Control LLC"
+  },
+  "0x014f:0x4744:0x3530": {
+    "description": "Garage Door Controller",
+    "label": "NGD00Z-4",
+    "manufacturer": "Nortek Security & Control LLC"
+  },
+  "0x014f:0x4744:0x3531": {
+    "description": "Z-Wave Garage Door Controller",
+    "label": "GD00Z-7",
+    "manufacturer": "Nortek Security & Control LLC"
+  },
+  "0x014f:0x4754:0x3038": {
+    "description": "Dimmable LED Light Bulb",
+    "label": "LB60Z-1",
+    "manufacturer": "Nortek Security & Control LLC"
+  },
+  "0x014f:0x4754:0x4252": {
+    "description": "Dimmable LED Light Bulb",
+    "label": "LBR30Z-1",
+    "manufacturer": "Nortek Security & Control LLC"
+  },
+  "0x014f:0x4c42:0x3133": {
+    "description": "LB65R6Z-1",
+    "label": "Smart Retrofit Lighting Kit",
+    "manufacturer": "Nortek Security & Control LLC"
+  },
+  "0x014f:0x5044:0x3533": {
+    "description": "300 Watt, Plug-In Dimmer Series 500",
+    "label": "PD300EMZ5-1",
+    "manufacturer": "Nortek Security & Control LLC"
+  },
+  "0x014f:0x5053:0x3531": {
+    "description": "Appliance Module",
+    "label": "PS15EMZ51",
+    "manufacturer": "Nortek Security & Control LLC"
+  },
+  "0x014f:0x5246:0x3133": {
+    "description": "Isolated Contact Fixture Module",
+    "label": "FS20Z",
+    "manufacturer": "Nortek Security & Control LLC"
+  },
+  "0x014f:0x5250:0x3030": {
+    "description": "Plug-In Appliance Module",
+    "label": "PS15Z",
+    "manufacturer": "Nortek Security & Control LLC"
+  },
+  "0x014f:0x5252:0x3530": {
+    "description": "Single Wall Outlet",
+    "label": "WO15Z",
+    "manufacturer": "Nortek Security & Control LLC"
+  },
+  "0x014f:0x5257:0x3533": {
+    "description": "Wall Mounted Switch",
+    "label": "WS15Z-1",
+    "manufacturer": "Nortek Security & Control LLC"
+  },
+  "0x014f:0x5343:0x3132": {
+    "description": "Wall Mounted Switch",
+    "label": "WA00Z-1",
+    "manufacturer": "Nortek Security & Control LLC"
+  },
+  "0x014f:0x5343:0x5a57": {
+    "description": "Elan System Controller",
+    "label": "EL-SC-100",
+    "manufacturer": "Nortek Security & Control LLC"
+  },
+  "0x014f:0x5442:0x5431": {
+    "description": "Z-Wave Plus Thermostat",
+    "label": "GoControl GC-TBZ48",
+    "manufacturer": "Nortek Security & Control LLC"
+  },
+  "0x014f:0x5442:0x5436": {
+    "description": "Z-Wave Plus Thermostat",
+    "label": "GoControl GC-TBZ48",
+    "manufacturer": "Nortek Security & Control LLC"
+  },
+  "0x014f:0x5442:0x5437": {
+    "description": "Z-Wave Plus Thermostat",
+    "label": "GoControl GC-TBZ48",
+    "manufacturer": "Nortek Security & Control LLC"
+  },
+  "0x014f:0x5457:0x3033": {
+    "description": "3-Way Wall Accessory Switch",
+    "label": "WT00Z-1",
+    "manufacturer": "Nortek Security & Control LLC"
+  },
+  "0x014f:0x5744:0x3530": {
+    "description": "An in-wall lighting dimmer",
+    "label": "WD500Z5-1",
+    "manufacturer": "Nortek Security & Control LLC"
+  },
+  "0x014f:0x5749:0x3135": {
+    "description": "Sprinkler Controller Supporting Flow Sensors, Rain Sensors and Moisture Sensors",
+    "label": "GoControl Smart Irrigation Controller",
+    "manufacturer": "Nortek Security & Control LLC"
+  },
+  "0x014f:0x5753:0x3535": {
+    "description": "Wall Mounted Switch",
+    "label": "WS15Z-1",
+    "manufacturer": "Nortek Security & Control LLC"
+  },
+  "0x014f:0x5754:0x3530": {
+    "description": "3-Way Wall Accessory Switch",
+    "label": "WT00Z5-1",
+    "manufacturer": "Linear (Nortek Security Control LLC)"
+  },
+  "0x0150:0x0001:0x0191": {
+    "description": "SmartThings Hub",
+    "label": "SmartThings Hub",
+    "manufacturer": "SmartThings, Inc."
+  },
+  "0x0150:0x0002:0x0006": {
+    "description": "SmartThings Hub",
+    "label": "SmartThings Hub",
+    "manufacturer": "SmartThings, Inc."
+  },
+  "0x0150:0x0002:0x000c": {
+    "description": "Samsung SmartThings Hub",
+    "label": "Hub",
+    "manufacturer": "SmartThings, Inc."
+  },
+  "0x0150:0x0004:0x0001": {
+    "description": "SmartThings Extend USB Adaptor",
+    "label": "Extend USB Adaptor",
+    "manufacturer": "SmartThings, Inc."
+  },
+  "0x0150:0x0007:0x001f": {
+    "description": "Samsung SmartThings Hub (2018)",
+    "label": "Samsung SmartThings Hub (2018)",
+    "manufacturer": "SmartThings, Inc."
+  },
+  "0x0150:0x0007:0x0020": {
+    "description": "Samsung SmartThings Hub (2018)",
+    "label": "Samsung SmartThings Hub (2018)",
+    "manufacturer": "SmartThings, Inc."
+  },
+  "0x0150:0x0007:0x002a": {
+    "description": "Samsung SmartThings Hub (2018)",
+    "label": "Samsung SmartThings Hub (2018)",
+    "manufacturer": "SmartThings, Inc."
+  },
+  "0x0150:0x000a:0x002b": {
+    "description": "SmartThings Link",
+    "label": "SmartThings Link",
+    "manufacturer": "SmartThings, Inc."
+  },
+  "0x0151:0x0001:0x0001": {
+    "description": "Energy switch",
+    "label": "SW-ESW02",
+    "manufacturer": "Sercomm Corp"
+  },
+  "0x0151:0x0002:0x0001": {
+    "description": "Clamp Power Meter",
+    "label": "SW-CLP01",
+    "manufacturer": "Sercomm Corp"
+  },
+  "0x0151:0x0003:0x0003": {
+    "description": "DoorWindow Sensor",
+    "label": "SW-DWS02N",
+    "manufacturer": "Sercomm Corp"
+  },
+  "0x0151:0x0101:0x0001": {
+    "description": "PIR Motion Sensor",
+    "label": "SW-PIR03N",
+    "manufacturer": "Sercomm Corp"
+  },
+  "0x0151:0x0301:0x0001": {
+    "description": "Z-Wave Smart Chime (Sound Switch)",
+    "label": "SW-SCM01N",
+    "manufacturer": "Sercomm Corp"
+  },
+  "0x0152:0x0003:0x0002": {
+    "description": "Power Switch",
+    "label": "GR-201N",
+    "manufacturer": "UFairy G.R. Tech"
+  },
+  "0x0152:0x0003:0x0003": {
+    "description": "Indoor Siren",
+    "label": "ZSE01",
+    "manufacturer": "UFairy G.R. Tech"
+  },
+  "0x0152:0x0003:0x0512": {
+    "description": "Water Main Shut-Off",
+    "label": "DMWV1",
+    "manufacturer": "UFairy G.R. Tech"
+  },
+  "0x0152:0x0202:0x0511": {
+    "description": "U-Fairy Control Valve",
+    "label": "GR-105",
+    "manufacturer": "UFairy G.R. Tech"
+  },
+  "0x0152:0x0500:0x0000": {
+    "description": "Water Leak Sensor Alarm",
+    "label": "Topvico TP-819ZW",
+    "manufacturer": "UFairy G.R. Tech"
+  },
+  "0x0152:0x0500:0x0001": {
+    "description": "Door/Window detector",
+    "label": "GR-309N",
+    "manufacturer": "UFairy G.R. Tech"
+  },
+  "0x0152:0x0500:0x0002": {
+    "description": "Smoke + Carbon Monoxide + Natural Liquefied Gas Leak Detector",
+    "label": "TP-807ZG",
+    "manufacturer": "UFairy G.R. Tech"
+  },
+  "0x0152:0x0500:0x0003": {
+    "description": "Z\u2011Wave Plus Motion Sensor",
+    "label": "ZSE02",
+    "manufacturer": "UFairy G.R. Tech"
+  },
+  "0x0152:0x0500:0x0004": {
+    "description": "Inwall dual switch",
+    "label": "GR-M-202N-2",
+    "manufacturer": "UFairy G.R. Tech"
+  },
+  "0x0152:0x0500:0x0005": {
+    "description": "3 Gang In-wall Switch",
+    "label": "GR-B3-3",
+    "manufacturer": "UFairy G.R. Tech"
+  },
+  "0x0152:0x0505:0x0001": {
+    "description": "Water Leak Sensor Alarm",
+    "label": "Topvico TP-819ZW",
+    "manufacturer": "UFairy G.R. Tech"
+  },
+  "0x0152:0x0a00:0x0004": {
+    "description": "3 Gang In-wall Switch",
+    "label": "GR-B3-3",
+    "manufacturer": "UFairy G.R. Tech"
+  },
+  "0x0154:0x0001:0x0001": {
+    "description": "Wall Plug Meter Switch",
+    "label": "123665",
+    "manufacturer": "Popp & Co"
+  },
+  "0x0154:0x0003:0x0001": {
+    "description": "Indoor/Outdoor Wall Plug Switch",
+    "label": "05438",
+    "manufacturer": "Popp & Co"
+  },
+  "0x0154:0x0003:0x000a": {
+    "description": "Popp Smart Outdoor Plug - IP44 rated",
+    "label": "POPE700397",
+    "manufacturer": "Popp & Co"
+  },
+  "0x0154:0x0003:0x1002": {
+    "description": "Power Plug",
+    "label": "700793",
+    "manufacturer": "Popp & Co"
+  },
+  "0x0154:0x0004:0x0002": {
+    "description": "POPP Solar Outdoor Siren 2",
+    "label": "700854",
+    "manufacturer": "Popp & Co"
+  },
+  "0x0154:0x0004:0x0003": {
+    "description": "CO Detector",
+    "label": "004407",
+    "manufacturer": "Popp & Co"
+  },
+  "0x0154:0x0004:0x0004": {
+    "description": "10 Year Smoke Detector with Siren Function",
+    "label": "009402",
+    "manufacturer": "Popp & Co"
+  },
+  "0x0154:0x0004:0x0007": {
+    "description": "POPP Door / Window Sensor",
+    "label": "POPE700982",
+    "manufacturer": "Popp & Co"
+  },
+  "0x0154:0x0004:0x0008": {
+    "description": "Water Leakage Sensor",
+    "label": "POPE700052",
+    "manufacturer": "Popp & Co"
+  },
+  "0x0154:0x0004:0x0011": {
+    "description": "POPP Rain-Sensor",
+    "label": "POPE700168",
+    "manufacturer": "Popp & Co"
+  },
+  "0x0154:0x0004:0x0014": {
+    "description": "Popp Mold detector",
+    "label": "POPE701202",
+    "manufacturer": "Popp & Co"
+  },
+  "0x0154:0x0005:0x0001": {
+    "description": "Electric Strike Lock Control",
+    "label": "012501",
+    "manufacturer": "Popp & Co"
+  },
+  "0x0154:0x0005:0x0002": {
+    "description": "Battery driven IP44 keypad for access control.",
+    "label": "700045",
+    "manufacturer": "Popp & Co"
+  },
+  "0x0154:0x0005:0x0003": {
+    "description": "Popp 09501 Flow Stop",
+    "label": "009501",
+    "manufacturer": "Popp & Co"
+  },
+  "0x0154:0x0100:0x0101": {
+    "description": "Wall Controller",
+    "label": "009303",
+    "manufacturer": "Popp & Co"
+  },
+  "0x0154:0x0100:0x0103": {
+    "description": "KFOB-C Remote-Control",
+    "label": "009204",
+    "manufacturer": "Popp & Co"
+  },
+  "0x0154:0x0100:0x0201": {
+    "description": "Smoke Detector and Siren",
+    "label": "004001",
+    "manufacturer": "Popp & Co"
+  },
+  "0x0154:0x0100:0x0400": {
+    "description": "Z-Weather",
+    "label": "005206",
+    "manufacturer": "Popp & Co"
+  },
+  "0x0154:0x0202:0x0511": {
+    "description": "Plug-in Switch",
+    "label": "123610 68G",
+    "manufacturer": "Popp & Co"
+  },
+  "0x0154:0x0202:0x0611": {
+    "description": "Dimmer",
+    "label": "123580 67G",
+    "manufacturer": "Popp & Co"
+  },
+  "0x0154:0x1100:0x0001": {
+    "description": "Wall Plug Switch",
+    "label": "123610",
+    "manufacturer": "Popp & Co"
+  },
+  "0x0154:0x1100:0x0002": {
+    "description": "Wall Plug Dimmer",
+    "label": "123580",
+    "manufacturer": "Popp & Co"
+  },
+  "0x0156:0x0001:0x0001": {
+    "description": "Vivint Master Control Panel ()",
+    "label": "CP01",
+    "manufacturer": "Vivint"
+  },
+  "0x0156:0x0001:0x0002": {
+    "description": "Vivint Smart Hub",
+    "label": "CP04",
+    "manufacturer": "Vivint"
+  },
+  "0x0156:0x5448:0x0001": {
+    "description": "Element Thermostat V2",
+    "label": "EV2",
+    "manufacturer": "Vivint"
+  },
+  "0x0157:0x0003:0x0002": {
+    "description": "Z-Wave Motor for water/gas ball valves",
+    "label": "EVC200",
+    "manufacturer": "EcoNet Controls"
+  },
+  "0x0157:0x0003:0x0512": {
+    "description": "Wireless Water Shutoff Valve",
+    "label": "EBV105",
+    "manufacturer": "EcoNet Controls"
+  },
+  "0x0157:0x0005:0x0003": {
+    "description": "Water Shutoff Valve",
+    "label": "GR-105",
+    "manufacturer": "EcoNet Controls"
+  },
+  "0x0157:0x0100:0x0100": {
+    "description": "Z-Vent ZWave Controlled HVAC Air Register",
+    "label": "EV100",
+    "manufacturer": "EcoNet Controls"
+  },
+  "0x0159:0x0001:0x0001": {
+    "description": "Flush dimmer",
+    "label": "ZMNHDA",
+    "manufacturer": "Qubino"
+  },
+  "0x0159:0x0001:0x0051": {
+    "description": "Flush Dimmer Plus",
+    "label": "ZMNHDD",
+    "manufacturer": "Qubino"
+  },
+  "0x0159:0x0001:0x0052": {
+    "description": "DIN Rail Dimmer",
+    "label": "ZMNHSD",
+    "manufacturer": "Qubino"
+  },
+  "0x0159:0x0001:0x0053": {
+    "description": "Flush Dimmer 0-10V",
+    "label": "ZMNHVD",
+    "manufacturer": "Qubino"
+  },
+  "0x0159:0x0001:0x0054": {
+    "description": "Qubino Flush RGBW Dimmer",
+    "label": "ZMNHWD",
+    "manufacturer": "Qubino"
+  },
+  "0x0159:0x0001:0x0055": {
+    "description": "Mini Dimmer",
+    "label": "ZMNHHD",
+    "manufacturer": "Qubino"
+  },
+  "0x0159:0x0002:0x0001": {
+    "description": "Flush 2 relays",
+    "label": "ZMNHBA",
+    "manufacturer": "Qubino"
+  },
+  "0x0159:0x0002:0x0002": {
+    "description": "Flush 1 relay",
+    "label": "ZMNHAA",
+    "manufacturer": "Qubino"
+  },
+  "0x0159:0x0002:0x0051": {
+    "description": "Flush 2 Relay",
+    "label": "ZMNHBD",
+    "manufacturer": "Qubino"
+  },
+  "0x0159:0x0002:0x0052": {
+    "description": "Flush 1 relay",
+    "label": "ZMNHAD",
+    "manufacturer": "Qubino"
+  },
+  "0x0159:0x0002:0x0053": {
+    "description": "Flush 1D relay",
+    "label": "ZMNHND",
+    "manufacturer": "Qubino"
+  },
+  "0x0159:0x0002:0x0054": {
+    "description": "Smart Plug",
+    "label": "Smart Plug 16A",
+    "manufacturer": "Qubino"
+  },
+  "0x0159:0x0003:0x0002": {
+    "description": "Flush Shutter",
+    "label": "ZMNHCA",
+    "manufacturer": "Qubino"
+  },
+  "0x0159:0x0003:0x0052": {
+    "description": "Flush Shutter",
+    "label": "ZMNHCD",
+    "manufacturer": "Qubino"
+  },
+  "0x0159:0x0003:0x0053": {
+    "description": "Flush Shutter DC",
+    "label": "ZMNHOD",
+    "manufacturer": "Qubino"
+  },
+  "0x0159:0x0004:0x0001": {
+    "description": "Flush Pilot",
+    "label": "ZMNHJA",
+    "manufacturer": "Qubino"
+  },
+  "0x0159:0x0004:0x0051": {
+    "description": "Flush Pilot",
+    "label": "ZMNHJD",
+    "manufacturer": "Qubino"
+  },
+  "0x0159:0x0004:0x0052": {
+    "description": "Flush pilot (DIN version)",
+    "label": "ZMNHUD",
+    "manufacturer": "Qubino"
+  },
+  "0x0159:0x0005:0x0001": {
+    "description": "Flush on/off thermostat",
+    "label": "ZMNHIA",
+    "manufacturer": "Qubino"
+  },
+  "0x0159:0x0005:0x0003": {
+    "description": "Flush PWM thermostat",
+    "label": "ZMNHLA",
+    "manufacturer": "Qubino"
+  },
+  "0x0159:0x0005:0x0051": {
+    "description": "Flush on/off thermostat",
+    "label": "ZMNHID",
+    "manufacturer": "Qubino"
+  },
+  "0x0159:0x0005:0x0052": {
+    "description": "Flush Heat & Cool Thermostat",
+    "label": "ZMNHKD",
+    "manufacturer": "Qubino"
+  },
+  "0x0159:0x0005:0x0053": {
+    "description": "Flush PWM Thermostat",
+    "label": "ZMNHLD",
+    "manufacturer": "Qubino"
+  },
+  "0x0159:0x0005:0x0054": {
+    "description": "Flush OnOff Thermostat 2",
+    "label": "ZMNKID",
+    "manufacturer": "Qubino"
+  },
+  "0x0159:0x0007:0x0052": {
+    "description": "Smart Meter",
+    "label": "ZMNHTD",
+    "manufacturer": "Qubino"
+  },
+  "0x0159:0x0007:0x0053": {
+    "description": "Multifunctional Weather Station",
+    "label": "ZMNHZD",
+    "manufacturer": "Qubino"
+  },
+  "0x0159:0x0007:0x0054": {
+    "description": "Qubino 3-Phase Smart Meter",
+    "label": "ZMNHXD",
+    "manufacturer": "Qubino"
+  },
+  "0x0159:0x0008:0x0051": {
+    "description": "Qubino LUXY Smart Light",
+    "label": "ZMNHQD",
+    "manufacturer": "Qubino"
+  },
+  "0x015a:0x1007:0x0002": {
+    "description": "Curtain motor",
+    "label": "Curtain Motor",
+    "manufacturer": "Jin Tao Bao"
+  },
+  "0x015a:0x3005:0x0003": {
+    "description": "Thermostat Control Panel",
+    "label": "JTB-3005-03",
+    "manufacturer": "Jin Tao Bao"
+  },
+  "0x015a:0x3011:0x0003": {
+    "description": "3CH Touch Wall Switch",
+    "label": "JTB-3011-03",
+    "manufacturer": "Jin Tao Bao"
+  },
+  "0x015b:0x0001:0x0001": {
+    "description": "Home IoT Hub",
+    "label": "IHU50",
+    "manufacturer": "LG Electronics"
+  },
+  "0x015b:0x0002:0x0001": {
+    "description": "Woofer IoT",
+    "label": "LAP255U",
+    "manufacturer": "LG Electronics"
+  },
+  "0x015b:0x0bb9:0x0bb9": {
+    "description": "SmartThinQ(Standard) Hub 2.0",
+    "label": "IGC73W",
+    "manufacturer": "LG Electronics"
+  },
+  "0x015d:0x0111:0x1e1c": {
+    "description": "In-Wall Smart Switch",
+    "label": "ZW30",
+    "manufacturer": "Willis Electric Co., Ltd."
+  },
+  "0x015d:0x0111:0x1f1c": {
+    "description": "Toggle Dimmer",
+    "label": "Zen24",
+    "manufacturer": "Willis Electric Co., Ltd."
+  },
+  "0x015d:0x0111:0x231c": {
+    "description": "Zooz Z-Wave On / Off Light Switch",
+    "label": "ZEN21",
+    "manufacturer": "Willis Electric Co., Ltd."
+  },
+  "0x015d:0x0112:0x1f1c": {
+    "description": "In-Wall Smart Dimmer",
+    "label": "ZW31",
+    "manufacturer": "Willis Electric Co., Ltd."
+  },
+  "0x015d:0x0112:0x241c": {
+    "description": "Zooz Z-Wave Dimmable Light Switch ZEN22",
+    "label": "ZEN22",
+    "manufacturer": "Willis Electric Co., Ltd."
+  },
+  "0x015d:0x0115:0x201c": {
+    "description": "Smart Outlet",
+    "label": "ZW32",
+    "manufacturer": "Willis Electric Co., Ltd."
+  },
+  "0x015d:0x0115:0x4e1c": {
+    "description": "In-line, in-wall 110v Z-Wave power switch",
+    "label": "ZW78S",
+    "manufacturer": "Willis Electric Co., Ltd."
+  },
+  "0x015d:0x0211:0x241c": {
+    "description": "Smart Plug(1 Channel)",
+    "label": "ZW36",
+    "manufacturer": "Willis Electric Co., Ltd."
+  },
+  "0x015d:0x0211:0x242c": {
+    "description": "In-Wall Smart Switch",
+    "label": "ZW661",
+    "manufacturer": "Willis Electric Co., Ltd."
+  },
+  "0x015d:0x0211:0x601c": {
+    "description": "Outdoor Smart Plug - 1 channel",
+    "label": "ZW96",
+    "manufacturer": "Willis Electric Co., Ltd."
+  },
+  "0x015d:0x0212:0x271c": {
+    "description": "Smart Plug Dimmer",
+    "label": "ZW39",
+    "manufacturer": "Willis Electric Co., Ltd."
+  },
+  "0x015d:0x0212:0x272c": {
+    "description": "In-Wall Smart Dimmer",
+    "label": "ZW671",
+    "manufacturer": "Willis Electric Co., Ltd."
+  },
+  "0x015d:0x0221:0x251c": {
+    "description": "Inovelli 2 channel smart plug",
+    "label": "ZW37",
+    "manufacturer": "Willis Electric Co., Ltd."
+  },
+  "0x015d:0x0221:0x611c": {
+    "description": "Outdoor Smart Plug - 2 channel",
+    "label": "ZW97",
+    "manufacturer": "show home"
+  },
+  "0x015d:0x0226:0x621c": {
+    "description": "Smart Plug(Built-in Energy Meter)",
+    "label": "ZW98",
+    "manufacturer": "Willis Electric Co., Ltd."
+  },
+  "0x015d:0x0621:0xf21c": {
+    "description": "2 Outlet Power Strip",
+    "label": "ZW1502",
+    "manufacturer": "Willis Electric Co., Ltd."
+  },
+  "0x015d:0x0621:0xf51c": {
+    "description": "Smart Energy Power Strip",
+    "label": "ZEN20",
+    "manufacturer": "Zooz"
+  },
+  "0x015d:0x0651:0xf51c": {
+    "description": "Smart Energy Power Strip",
+    "label": "ZEN20",
+    "manufacturer": "Zooz"
+  },
+  "0x015d:0x1111:0x1e1c": {
+    "description": "Wall mounted switch",
+    "label": "ZEN23",
+    "manufacturer": "Willis Electric Co., Ltd."
+  },
+  "0x015d:0x1215:0x261c": {
+    "description": "Smart Plug(built-in energy meter)",
+    "label": "ZW38",
+    "manufacturer": "Willis Electric Co., Ltd."
+  },
+  "0x015d:0x1215:0x262c": {
+    "description": "Show Home, In-Wall-Smart-Outlet BSI",
+    "label": "ZW691",
+    "manufacturer": "Willis Electric Co., Ltd."
+  },
+  "0x015d:0x1e00:0x1e00": {
+    "description": "Inovelli In-Wall Switch (On/Off) Scene Enabled",
+    "label": "NZW30T",
+    "manufacturer": "Willis Electric Co., Ltd."
+  },
+  "0x015d:0x1e02:0x1e02": {
+    "description": "Inovelli In-Wall Switch (On/Off) Scene Enabled",
+    "label": "NZW30T",
+    "manufacturer": "Willis Electric Co., Ltd."
+  },
+  "0x015d:0x1f00:0x1f00": {
+    "description": "In-wall Dimming Switch",
+    "label": "NZW31",
+    "manufacturer": "Willis Electric Co., Ltd."
+  },
+  "0x015d:0x1f01:0x1f01": {
+    "description": "In-wall Dimming Switch",
+    "label": "NZW31",
+    "manufacturer": "Willis Electric Co., Ltd."
+  },
+  "0x015d:0x2003:0x701c": {
+    "description": "Motion Sensor",
+    "label": "ZW112",
+    "manufacturer": "Willis Electric Co., Ltd."
+  },
+  "0x015d:0x2003:0xb11c": {
+    "description": "Door Window Sensor",
+    "label": "ZW1101",
+    "manufacturer": "Willis Electric Co., Ltd."
+  },
+  "0x015d:0x2003:0xb31c": {
+    "description": "Smoke Sensor",
+    "label": "ZW1103",
+    "manufacturer": "Willis Electric Co., Ltd."
+  },
+  "0x015d:0x2003:0xb41c": {
+    "description": "Flood Sensor",
+    "label": "ZW-1104",
+    "manufacturer": "Willis Electric Co., Ltd."
+  },
+  "0x015d:0x2003:0xb51c": {
+    "description": "Shock Sensor",
+    "label": "ZW1105",
+    "manufacturer": "Willis Electric Co., Ltd."
+  },
+  "0x015d:0x2003:0xc11c": {
+    "description": "Door/Window Sensor",
+    "label": "ZW1201",
+    "manufacturer": "Willis Electric Co., Ltd."
+  },
+  "0x015d:0x2003:0xc41c": {
+    "description": "Flood Sensor",
+    "label": "ZW1204",
+    "manufacturer": "Willis Electric Co., Ltd."
+  },
+  "0x015d:0x2500:0x2500": {
+    "description": "Inovelli Smart Plug (2 Channel with Scene Control)",
+    "label": "NZW37",
+    "manufacturer": "Willis Electric Co., Ltd."
+  },
+  "0x015d:0x2700:0x2700": {
+    "description": "Dimming Plug",
+    "label": "NZW39",
+    "manufacturer": "Willis Electric Co., Ltd."
+  },
+  "0x015d:0x4000:0x0f1c": {
+    "description": "Siren Box",
+    "label": "ZW15",
+    "manufacturer": "Willis Electric Co., Ltd."
+  },
+  "0x015d:0x6000:0x6000": {
+    "description": "Outdoor Plug-in Module (1-Channel)",
+    "label": "NZW96",
+    "manufacturer": "Willis Electric Co., Ltd."
+  },
+  "0x015d:0x6100:0x6100": {
+    "description": "Inovelli Outdoor Smart Plug (2 Channel)",
+    "label": "NZW97",
+    "manufacturer": "Willis Electric Co., Ltd."
+  },
+  "0x015d:0xb003:0xc11c": {
+    "description": "Door/Window Sensor",
+    "label": "NZW1201",
+    "manufacturer": "Willis Electric Co., Ltd."
+  },
+  "0x015d:0xb111:0x1e1c": {
+    "description": "In-Wall Smart Switch",
+    "label": "ZW30",
+    "manufacturer": "Willis Electric Co., Ltd."
+  },
+  "0x015e:0x8015:0x0003": {
+    "description": "KAS-600 Z-Wave Electronic Lock",
+    "label": "LS-8015-ZW",
+    "manufacturer": "Locstar Technology Co., Ltd."
+  },
+  "0x015f:0x0301:0x1001": {
+    "description": "MCO HOME Micro Shutter",
+    "label": "MH-C221",
+    "manufacturer": "McoHome Technology Co., Ltd."
+  },
+  "0x015f:0x0301:0x3001": {
+    "description": "MCO HOME Micro Shutter",
+    "label": "MH-C221",
+    "manufacturer": "McoHome Technology Co., Ltd."
+  },
+  "0x015f:0x0302:0x1000": {
+    "description": "MCO HOME Micro Shutter",
+    "label": "MH-C221",
+    "manufacturer": "McoHome Technology Co., Ltd."
+  },
+  "0x015f:0x0604:0x0101": {
+    "description": "Programmable Thermostat",
+    "label": "MH6-HP",
+    "manufacturer": "McoHome Technology Co., Ltd."
+  },
+  "0x015f:0x0701:0x5102": {
+    "description": "Water / Electrical Heating Thermostat",
+    "label": "MH7H",
+    "manufacturer": "McoHome Technology Co., Ltd."
+  },
+  "0x015f:0x0702:0x3102": {
+    "description": "Water/Electrical Heating Thermostat",
+    "label": "MH7",
+    "manufacturer": "McoHome Technology Co., Ltd."
+  },
+  "0x015f:0x0702:0x5102": {
+    "description": "Water / Electrical Heating Thermostat",
+    "label": "MH7H",
+    "manufacturer": "McoHome Technology Co., Ltd."
+  },
+  "0x015f:0x0712:0x5102": {
+    "description": "Water / Electrical Heating Thermostat",
+    "label": "MH7H",
+    "manufacturer": "McoHome Technology Co., Ltd."
+  },
+  "0x015f:0x0732:0x5102": {
+    "description": "Water / Electrical Heating Thermostat",
+    "label": "MH7H",
+    "manufacturer": "McoHome Technology Co., Ltd."
+  },
+  "0x015f:0x0801:0x3102": {
+    "description": "Fan Coil Thermostat (Zwave Plus)",
+    "label": "MH8-FC",
+    "manufacturer": "McoHome Technology Co., Ltd."
+  },
+  "0x015f:0x0801:0x5102": {
+    "description": "Fan Coil Thermostat (Zwave Plus)",
+    "label": "MH8-FC",
+    "manufacturer": "McoHome Technology Co., Ltd."
+  },
+  "0x015f:0x0802:0x3102": {
+    "description": "Fan Coil Thermostat (Zwave Plus)",
+    "label": "MH8-FC",
+    "manufacturer": "McoHome Technology Co., Ltd."
+  },
+  "0x015f:0x0802:0x5102": {
+    "description": "Fan Coil Thermostat (Zwave Plus)",
+    "label": "MH8-FC",
+    "manufacturer": "McoHome Technology Co., Ltd."
+  },
+  "0x015f:0x0803:0x5102": {
+    "description": "Fan Coil Thermostat (Zwave Plus)",
+    "label": "MH8-FC",
+    "manufacturer": "McoHome Technology Co., Ltd."
+  },
+  "0x015f:0x0901:0x3102": {
+    "description": "CO2 Monitor Air quality detector",
+    "label": "MH9-CO2-WD",
+    "manufacturer": "McoHome Technology Co., Ltd."
+  },
+  "0x015f:0x0901:0x5102": {
+    "description": "CO2 Monitor Air quality detector",
+    "label": "MH9-CO2-WA",
+    "manufacturer": "McoHome Technology Co., Ltd."
+  },
+  "0x015f:0x0905:0x0201": {
+    "description": "CO2 Monitor Air quality detector",
+    "label": "MH9-CO2-WD",
+    "manufacturer": "McoHome Technology Co., Ltd."
+  },
+  "0x015f:0x0a01:0x3102": {
+    "description": "PM2.5 Monitor",
+    "label": "MH10-PM2.5-WA",
+    "manufacturer": "McoHome Technology Co., Ltd."
+  },
+  "0x015f:0x0a01:0x5102": {
+    "description": "PM2.5 Monitor (Zwave Plus)",
+    "label": "MH10-PM2.5-WA/WD",
+    "manufacturer": "McoHome Technology Co., Ltd."
+  },
+  "0x015f:0x0a05:0x0100": {
+    "description": "PM2.5 Monitor",
+    "label": "MH10-PM2.5-WA",
+    "manufacturer": "McoHome Technology Co., Ltd."
+  },
+  "0x015f:0x0a05:0x0201": {
+    "description": "PM2.5 Monitor",
+    "label": "MH10-PM2.5-WA",
+    "manufacturer": "McoHome Technology Co., Ltd."
+  },
+  "0x015f:0x2121:0x1352": {
+    "description": "Mini Combo Switch",
+    "label": "MH-S212",
+    "manufacturer": "McoHome Technology Co., Ltd."
+  },
+  "0x015f:0x220a:0x1352": {
+    "description": "Micro Dimmer",
+    "label": "MH-P220",
+    "manufacturer": "McoHome Technology Co., Ltd."
+  },
+  "0x015f:0x220a:0x5102": {
+    "description": "Micro Dimmer",
+    "label": "MH-P220",
+    "manufacturer": "McoHome Technology Co., Ltd."
+  },
+  "0x015f:0x3102:0x0202": {
+    "description": "Two Way Switch",
+    "label": "MH-S312",
+    "manufacturer": "McoHome Technology Co., Ltd."
+  },
+  "0x015f:0x3102:0x0204": {
+    "description": "Touch Panel Switch 4 Button",
+    "label": "MH-S314",
+    "manufacturer": "McoHome Technology Co., Ltd."
+  },
+  "0x015f:0x3111:0x1302": {
+    "description": "Touch Panel Switch (Single) High inrush current",
+    "label": "MH-S311H",
+    "manufacturer": "McoHome Technology Co., Ltd."
+  },
+  "0x015f:0x3111:0x5102": {
+    "description": "Touch Panel Switch (Single) High inrush current",
+    "label": "MH-S311H",
+    "manufacturer": "McoHome Technology Co., Ltd."
+  },
+  "0x015f:0x3121:0x1302": {
+    "description": "Two Way Switch",
+    "label": "MH-S312",
+    "manufacturer": "McoHome Technology Co., Ltd."
+  },
+  "0x015f:0x3121:0x5102": {
+    "description": "Two Way Switch",
+    "label": "MH-S312",
+    "manufacturer": "McoHome Technology Co., Ltd."
+  },
+  "0x015f:0x3122:0x5102": {
+    "description": "Two Way Switch",
+    "label": "MH-S312",
+    "manufacturer": "McoHome Technology Co., Ltd."
+  },
+  "0x015f:0x3141:0x1302": {
+    "description": "Touch Panel Switch 4 Button",
+    "label": "MH-S314",
+    "manufacturer": "McoHome Technology Co., Ltd."
+  },
+  "0x015f:0x3141:0x5102": {
+    "description": "Touch Panel Switch 4 Button",
+    "label": "MH-S314",
+    "manufacturer": "McoHome Technology Co., Ltd."
+  },
+  "0x015f:0x3900:0x5102": {
+    "description": "Boiler Thermostat",
+    "label": "MH3900",
+    "manufacturer": "McoHome Technology Co., Ltd."
+  },
+  "0x015f:0x4102:0x0201": {
+    "description": "Touch Panel Switch 1 Button",
+    "label": "MH-S411",
+    "manufacturer": "McoHome Technology Co., Ltd."
+  },
+  "0x015f:0x4102:0x0202": {
+    "description": "Touch Panel Switch 2 Button",
+    "label": "MH-S412",
+    "manufacturer": "McoHome Technology Co., Ltd."
+  },
+  "0x015f:0x4111:0x1302": {
+    "description": "Touch Panel Switch 1 Button",
+    "label": "MH-S411",
+    "manufacturer": "McoHome Technology Co., Ltd."
+  },
+  "0x015f:0x4111:0x5102": {
+    "description": "Touch Panel Switch 1 Button",
+    "label": "MH-S411",
+    "manufacturer": "McoHome Technology Co., Ltd."
+  },
+  "0x015f:0x4121:0x1302": {
+    "description": "Touch Panel Switch 2 Button",
+    "label": "MH-S412",
+    "manufacturer": "McoHome Technology Co., Ltd."
+  },
+  "0x015f:0x4121:0x5102": {
+    "description": "Touch Panel Switch 2 Button",
+    "label": "MH-S412",
+    "manufacturer": "McoHome Technology Co., Ltd."
+  },
+  "0x015f:0x5111:0x1406": {
+    "description": "MCOHome touch switch Relay",
+    "label": "MH-S511-IL",
+    "manufacturer": "McoHome Technology Co., Ltd."
+  },
+  "0x015f:0x511a:0x1452": {
+    "description": "MCO Home Dimmer Switch",
+    "label": "MH-P311",
+    "manufacturer": "McoHome Technology Co., Ltd."
+  },
+  "0x015f:0x5121:0x1406": {
+    "description": "MCOHome Touch Dual Switch Relay",
+    "label": "MH-S512-IL",
+    "manufacturer": "McoHome Technology Co., Ltd."
+  },
+  "0x015f:0x5121:0x5103": {
+    "description": "Touch Panel Switch 2-Way",
+    "label": "MH-S512",
+    "manufacturer": "McoHome Technology Co., Ltd."
+  },
+  "0x015f:0x5131:0x5103": {
+    "description": "Touch Panel Switch 3-Way",
+    "label": "MH-S513",
+    "manufacturer": "McoHome Technology Co., Ltd."
+  },
+  "0x015f:0xc221:0x5102": {
+    "description": "MCO HOME Micro Shutter",
+    "label": "MH-C221",
+    "manufacturer": "McoHome Technology Co., Ltd."
+  },
+  "0x015f:0xc321:0x5102": {
+    "description": "Shutter Panel",
+    "label": "MH-S521",
+    "manufacturer": "McoHome Technology Co., Ltd."
+  },
+  "0x015f:0xc421:0x5102": {
+    "description": "MCO HOME Micro Shutter",
+    "label": "MH-C421",
+    "manufacturer": "McoHome Technology Co., Ltd."
+  },
+  "0x015f:0xc521:0x5101": {
+    "description": "Shutter Panel",
+    "label": "MH-S521",
+    "manufacturer": "McoHome Technology Co., Ltd."
+  },
+  "0x015f:0xd311:0x5102": {
+    "description": "MCOHome Dimmer Switch",
+    "label": "MH-DT311/MH-DT411",
+    "manufacturer": "McoHome Technology Co., Ltd."
+  },
+  "0x015f:0xd411:0x5102": {
+    "description": "MCOHome Dimmer Switch",
+    "label": "MH-DT311/MH-DT411",
+    "manufacturer": "McoHome Technology Co., Ltd."
+  },
+  "0x0160:0x0001:0x0001": {
+    "description": "Z-Wave extender",
+    "label": "ES800ZWP_EU_MXX",
+    "manufacturer": "Essence Security"
+  },
+  "0x0162:0x0001:0x03e9": {
+    "description": "AV Scenario Controller with universal IR",
+    "label": "HSK-100Z",
+    "manufacturer": "HomeScenario"
+  },
+  "0x0163:0x3001:0x0301": {
+    "description": "Queenlock Z-Wave Deadbolt Lock",
+    "label": "ZW-702",
+    "manufacturer": "Queenlock Ind. Co., Ltd."
+  },
+  "0x0165:0x0001:0x0001": {
+    "description": "Smart Plug",
+    "label": "ASP-3-1",
+    "manufacturer": "ID-RF"
+  },
+  "0x0165:0x0001:0x0003": {
+    "description": "Z-Wave Plus Micro Smart Plug ON/OFF",
+    "label": "MSP-3-1-X1",
+    "manufacturer": "ID-RF"
+  },
+  "0x0165:0x0002:0x0001": {
+    "description": "Octan Remote Control",
+    "label": "CRC-3100",
+    "manufacturer": "ID-RF"
+  },
+  "0x0165:0x0002:0x0002": {
+    "description": "Remote Control",
+    "label": "Soft Remote",
+    "manufacturer": "ID-RF"
+  },
+  "0x0165:0x0002:0x0003": {
+    "description": "Wall Switch",
+    "label": "CWS-3101",
+    "manufacturer": "ID-RF"
+  },
+  "0x0166:0x0002:0x0001": {
+    "description": "RemSwiid Z-Wave remote controller",
+    "label": "SW-ZRC",
+    "manufacturer": "CBCC Domotique SAS"
+  },
+  "0x0166:0x0002:0x0004": {
+    "description": "ZURC Remote Control",
+    "label": "SW-ZRC2",
+    "manufacturer": "CBCC Domotique SAS"
+  },
+  "0x0166:0x0003:0x0001": {
+    "description": "SwiidCam+",
+    "label": "SW-ZCAM1",
+    "manufacturer": "CBCC Domotique SAS"
+  },
+  "0x0166:0x0100:0x0100": {
+    "description": "Cord Switch",
+    "label": "SW-ZCS",
+    "manufacturer": "CBCC Domotique SAS"
+  },
+  "0x0166:0x2007:0x0706": {
+    "description": "Swiid Plug",
+    "label": "SW-ZAP-1",
+    "manufacturer": "CBCC Domotique SAS"
+  },
+  "0x0167:0x0001:0x0001": {
+    "description": "Wireless Alarm System with Integrated Home Automation",
+    "label": "WS900-29",
+    "manufacturer": "SecureNet Technologies"
+  },
+  "0x0167:0x0002:0x0001": {
+    "description": "Wireless Alarm System with Integrated Home Automation",
+    "label": "WS901",
+    "manufacturer": "SecureNet Technologies"
+  },
+  "0x0167:0x0003:0x0001": {
+    "description": "Wireless Alarm System with Integrated Home Automation",
+    "label": "WS901",
+    "manufacturer": "SecureNet Technologies"
+  },
+  "0x0169:0x0001:0x0001": {
+    "description": "Z Weather",
+    "label": "POPE005206",
+    "manufacturer": "B\u00f6nig und Kallenbach oHG"
+  },
+  "0x016a:0x0001:0x0065": {
+    "description": "Cube",
+    "label": "FT101",
+    "manufacturer": "Fantem"
+  },
+  "0x016a:0x0002:0x0064": {
+    "description": "Oomi Multisensor",
+    "label": "FT100",
+    "manufacturer": "Fantem"
+  },
+  "0x016a:0x0002:0x0070": {
+    "description": "Door/Window Sensor 6",
+    "label": "FT112",
+    "manufacturer": "Fantem"
+  },
+  "0x016a:0x0002:0x0082": {
+    "description": "Wall-mount four Button",
+    "label": "FT130",
+    "manufacturer": "Fantem"
+  },
+  "0x016a:0x0003:0x0060": {
+    "description": "Plug-in Switch",
+    "label": "FT096",
+    "manufacturer": "Fantem"
+  },
+  "0x016a:0x0003:0x0062": {
+    "description": "9W Color Light Bulb",
+    "label": "FT098",
+    "manufacturer": "Fantem"
+  },
+  "0x016a:0x0003:0x006f": {
+    "description": "Nano Dimmer",
+    "label": "FT111",
+    "manufacturer": "Fantem"
+  },
+  "0x016a:0x0003:0x0074": {
+    "description": "In-Wall Smart Switch",
+    "label": "FT116",
+    "manufacturer": "Fantem"
+  },
+  "0x016a:0x0003:0x0079": {
+    "description": "LED RGBWW Strip",
+    "label": "FT121",
+    "manufacturer": "Fantem"
+  },
+  "0x016a:0x0003:0x008c": {
+    "description": "Dual Nano Switch with Energy Metering",
+    "label": "FT132",
+    "manufacturer": "Fantem"
+  },
+  "0x016a:0x0003:0x008d": {
+    "description": "In-Wall Shutter",
+    "label": "FT141",
+    "manufacturer": "Fantem"
+  },
+  "0x016a:0x0101:0x0065": {
+    "description": "Cube",
+    "label": "FT101",
+    "manufacturer": "Fantem"
+  },
+  "0x016a:0x0102:0x0066": {
+    "description": "Oomi Touch",
+    "label": "FT102",
+    "manufacturer": "Fantem"
+  },
+  "0x016a:0x0103:0x0060": {
+    "description": "Plug-in Switch",
+    "label": "FT096",
+    "manufacturer": "Fantem"
+  },
+  "0x016a:0x0201:0x0065": {
+    "description": "Cube",
+    "label": "FT101",
+    "manufacturer": "Fantem"
+  },
+  "0x016a:0x0203:0x0060": {
+    "description": "Plug-in Switch",
+    "label": "FT096",
+    "manufacturer": "Fantem"
+  },
+  "0x016a:0x0203:0x006f": {
+    "description": "Nano Dimmer",
+    "label": "FT111",
+    "manufacturer": "Fantem"
+  },
+  "0x016a:0x0203:0x0084": {
+    "description": "Dual Nano Switch with Energy Metering",
+    "label": "FT132",
+    "manufacturer": "Fantem"
+  },
+  "0x016a:0x0301:0x0065": {
+    "description": "Cube",
+    "label": "FT101",
+    "manufacturer": "Fantem"
+  },
+  "0x016a:0x1d02:0x0070": {
+    "description": "Door / Window Sensor",
+    "label": "FT112-K",
+    "manufacturer": "Fantem"
+  },
+  "0x016a:0x1d02:0x0082": {
+    "description": "Oomi Mote",
+    "label": "FT130-K",
+    "manufacturer": "Fantem"
+  },
+  "0x016a:0x1d03:0x0062": {
+    "description": "Bulb",
+    "label": "FT098-K55",
+    "manufacturer": "Fantem"
+  },
+  "0x016a:0x1d03:0x006f": {
+    "description": "In-Wall Dimmer",
+    "label": "FT111-K",
+    "manufacturer": "Fantem"
+  },
+  "0x016b:0x0001:0x0002": {
+    "description": "SAGE",
+    "label": "204063",
+    "manufacturer": "Echostar"
+  },
+  "0x016d:0x3007:0x0001": {
+    "description": "Smart-Touch Electronic Drapery Drive",
+    "label": "DM0027 Mini",
+    "manufacturer": "Guangzhou Ruixiang M&E Co., Ltd."
+  },
+  "0x0170:0x0000:0x0000": {
+    "description": "SiteSage",
+    "label": "950-000012",
+    "manufacturer": "Powerhouse Dynamics"
+  },
+  "0x0171:0x0001:0x0002": {
+    "description": "WeBeHome gateway",
+    "label": "HG2",
+    "manufacturer": "WeBeHome AB"
+  },
+  "0x0171:0x0001:0x0003": {
+    "description": "Home Gateway 2 Plus",
+    "label": "WBH-HG2+",
+    "manufacturer": "WeBeHome AB"
+  },
+  "0x0172:0x0001:0x0001": {
+    "description": "PassivLiving Hub",
+    "label": "PL-HB1-ZW",
+    "manufacturer": "PassivSystems Ltd."
+  },
+  "0x0173:0x0003:0x0002": {
+    "description": "Water Valve Control",
+    "label": "LGZW",
+    "manufacturer": "Leak Intelligence, LLC"
+  },
+  "0x0173:0x0003:0x0003": {
+    "description": "Leak Gopher Meter Reader",
+    "label": "LGRM",
+    "manufacturer": "Leak Intelligence, LLC"
+  },
+  "0x0173:0x4c47:0x4c44": {
+    "description": "Leak Gopher Z-Wave Leak Detector",
+    "label": "LGZWL",
+    "manufacturer": "Leak Intelligence, LLC"
+  },
+  "0x0175:0x0000:0x0001": {
+    "description": "devolo Home Control Central Unit",
+    "label": "MT2600 / MT2601",
+    "manufacturer": "Devolo"
+  },
+  "0x0175:0x0001:0x0001": {
+    "description": "Smart Energy Plug-in Switch",
+    "label": "PAN11",
+    "manufacturer": "Devolo"
+  },
+  "0x0175:0x0001:0x0011": {
+    "description": "Home Control Metering Plug",
+    "label": "MT02646",
+    "manufacturer": "Devolo"
+  },
+  "0x0175:0x0001:0x0012": {
+    "description": "Home Control Metering Plug",
+    "label": "MT02792",
+    "manufacturer": "Devolo"
+  },
+  "0x0175:0x0001:0x0051": {
+    "description": "Devolo Home Control Dimmer FM MT2760",
+    "label": "MT2760",
+    "manufacturer": "Devolo"
+  },
+  "0x0175:0x0001:0x0301": {
+    "description": "Home Control Key",
+    "label": "MT:2653",
+    "manufacturer": "Devolo"
+  },
+  "0x0175:0x0002:0x000d": {
+    "description": "Motion Sensor",
+    "label": "MT02647",
+    "manufacturer": "Devolo"
+  },
+  "0x0175:0x0002:0x000e": {
+    "description": "Door/Window Contact",
+    "label": "MT02648",
+    "manufacturer": "Devolo"
+  },
+  "0x0175:0x0002:0x0018": {
+    "description": "Multisensor",
+    "label": "PST02-1B",
+    "manufacturer": "Devolo"
+  },
+  "0x0175:0x0002:0x0020": {
+    "description": "Humidity Sensor",
+    "label": "MT02755",
+    "manufacturer": "Devolo"
+  },
+  "0x0175:0x0002:0x0021": {
+    "description": "MT2756 Flood Sensor",
+    "label": "MT2756",
+    "manufacturer": "Devolo"
+  },
+  "0x0175:0x0002:0x0052": {
+    "description": "Home Control Wall Mounted Switch",
+    "label": "MT2759",
+    "manufacturer": "Devolo"
+  },
+  "0x0175:0x0003:0x0052": {
+    "description": "Home Control Shutter",
+    "label": "MT2761",
+    "manufacturer": "Devolo"
+  },
+  "0x0175:0x0004:0x000a": {
+    "description": "Multisound indoor siren",
+    "label": "ph-pse02",
+    "manufacturer": "Devolo"
+  },
+  "0x0175:0x0100:0x0101": {
+    "description": "Scene Switch",
+    "label": "MT2652",
+    "manufacturer": "Devolo"
+  },
+  "0x0175:0x0100:0x0102": {
+    "description": "Keyfob",
+    "label": "MT2653",
+    "manufacturer": "Devolo"
+  },
+  "0x0175:0x0502:0x1000": {
+    "description": "Home Control Smoke Detector",
+    "label": "09813",
+    "manufacturer": "Devolo"
+  },
+  "0x0175:0x2004:0x04a4": {
+    "description": "Home Control Smoke Detector",
+    "label": "09813",
+    "manufacturer": "Devolo"
+  },
+  "0x0176:0x0001:0x0002": {
+    "description": "TellStick ZNet Lite",
+    "label": "TZNETLIT",
+    "manufacturer": "Telldus Technologies AB"
+  },
+  "0x0176:0x0003:0x0001": {
+    "description": "Wall Plug Switch",
+    "label": "TZWP-100",
+    "manufacturer": "Telldus Technologies AB"
+  },
+  "0x0176:0x0003:0x0002": {
+    "description": "Wall Plug Switch",
+    "label": "TZWP-100",
+    "manufacturer": "Telldus Technologies AB"
+  },
+  "0x0176:0x0003:0x0003": {
+    "description": "Telldus socket and energy meter",
+    "label": "TZWP-102",
+    "manufacturer": "Telldus Technologies AB"
+  },
+  "0x0176:0x0005:0x0001": {
+    "description": "Door/window sensor",
+    "label": "TZDW-100",
+    "manufacturer": "Telldus Technologies AB"
+  },
+  "0x0178:0x4252:0x3230": {
+    "description": "Nexia Bridge",
+    "label": "BR200NX",
+    "manufacturer": "Nexia Home Intelligence"
+  },
+  "0x0178:0x4442:0x3130": {
+    "description": "Doorbell",
+    "label": "DB100Z",
+    "manufacturer": "Nexia Home Intelligence"
+  },
+  "0x0178:0x5448:0x3130": {
+    "description": "Remote Temperature and Humidity Sensor",
+    "label": "TH100NX",
+    "manufacturer": "Nexia Home Intelligence"
+  },
+  "0x0178:0x5a44:0x414e": {
+    "description": "VeriLock Translator",
+    "label": "9125051",
+    "manufacturer": "Nexia Home Intelligence"
+  },
+  "0x0179:0x0013:0x0021": {
+    "description": "CH-201 Thermostat",
+    "label": "CH-201",
+    "manufacturer": "ConnectHome"
+  },
+  "0x0179:0x0021:0x0011": {
+    "description": "CH-601 THE ELECTRIC CRANE",
+    "label": "CH-601",
+    "manufacturer": "ConnectHome"
+  },
+  "0x017c:0x0001:0x000a": {
+    "description": "heatapp! repeater S2",
+    "label": "9601921000",
+    "manufacturer": "EbV"
+  },
+  "0x017c:0x0006:0x0003": {
+    "description": "heatapp! floor is a controller for thermal actuators in underfloor heating installations and is part of the heatapp! system, providing individual circ",
+    "label": "heatapp! floor",
+    "manufacturer": "EbV"
+  },
+  "0x017e:0x0001:0x0002": {
+    "description": "FlexHub",
+    "label": "TGFX-HUB1",
+    "manufacturer": "Telular"
+  },
+  "0x017f:0x0001:0x0001": {
+    "description": "Wink Hub",
+    "label": "PWHUB-WH01",
+    "manufacturer": "Wink Inc."
+  },
+  "0x017f:0x0100:0x0001": {
+    "description": "Door/Window Sensor",
+    "label": "D/W SENSOR",
+    "manufacturer": "Wink Inc."
+  },
+  "0x017f:0x0101:0x0001": {
+    "description": "Motion Sensor",
+    "label": "Motion Sensor",
+    "manufacturer": "Wink Inc."
+  },
+  "0x017f:0x0200:0x0001": {
+    "description": "Wink Siren",
+    "label": "Siren",
+    "manufacturer": "Wink Inc."
+  },
+  "0x0182:0x0001:0x0001": {
+    "description": "Securifi Almond+",
+    "label": "ALMP-BLK",
+    "manufacturer": "Securifi Ltd."
+  },
+  "0x0183:0x0201:0x0701": {
+    "description": "Universe Future Gateway",
+    "label": "ZWG2000AG",
+    "manufacturer": "Universe Future"
+  },
+  "0x0184:0x4447:0x3031": {
+    "description": "Plug-in On/Off Switch",
+    "label": "PA-100",
+    "manufacturer": "Dragon Tech Industrial, Ltd."
+  },
+  "0x0184:0x4447:0x3033": {
+    "description": "Wall On/Off Switch",
+    "label": "WS-100",
+    "manufacturer": "Dragon Tech Industrial, Ltd."
+  },
+  "0x0184:0x4744:0x3032": {
+    "description": "Plug in Dimmer Switch",
+    "label": "PD-100",
+    "manufacturer": "Dragon Tech Industrial, Ltd."
+  },
+  "0x0184:0x4754:0x3038": {
+    "description": "HomeSeer Smart Bulb",
+    "label": "HS-DTA19+",
+    "manufacturer": "Dragon Tech Industrial, Ltd."
+  },
+  "0x0185:0x0003:0x0009": {
+    "description": "PIR motion sensor",
+    "label": "ZM-800",
+    "manufacturer": "Ningbo Sentek Electronics Co., Ltd."
+  },
+  "0x0189:0x759e:0x6aff": {
+    "description": "Mezzo",
+    "label": "106-360",
+    "manufacturer": "Ness Corporation Pty Ltd."
+  },
+  "0x018b:0x0002:0x0001": {
+    "description": "IoT Hub",
+    "label": "GWG-02",
+    "manufacturer": "Grib"
+  },
+  "0x018b:0x0002:0x0003": {
+    "description": "IoT Hub",
+    "label": "GWG-02",
+    "manufacturer": "Grib"
+  },
+  "0x018b:0x0003:0x0001": {
+    "description": "IoT Hub",
+    "label": "GIHG20",
+    "manufacturer": "Grib"
+  },
+  "0x018b:0x0004:0x0001": {
+    "description": "IoT Hub",
+    "label": "IRHG-01",
+    "manufacturer": "Grib"
+  },
+  "0x018b:0x0004:0x0002": {
+    "description": "IoT Hub",
+    "label": "IRHG-01",
+    "manufacturer": "Grib"
+  },
+  "0x018b:0x0040:0x0100": {
+    "description": "Smart Gas Controller",
+    "label": "GCR-01S",
+    "manufacturer": "Grib"
+  },
+  "0x018e:0x0001:0x0001": {
+    "description": "Door Contact",
+    "label": "DC-15ZW",
+    "manufacturer": "Climax Technology, Ltd."
+  },
+  "0x018e:0x0001:0x0002": {
+    "description": "Z-Wave Motion Sensor",
+    "label": "IR-16ZW",
+    "manufacturer": "Climax Technology, Ltd."
+  },
+  "0x018e:0x0001:0x0007": {
+    "description": "Door Contact",
+    "label": "DC-23ZW",
+    "manufacturer": "Climax Technology, Ltd."
+  },
+  "0x018e:0x0002:0x0001": {
+    "description": "",
+    "label": "SRAC-23ZW",
+    "manufacturer": "Climax Technology, Ltd."
+  },
+  "0x018e:0x0002:0x000b": {
+    "description": "Outdoor Siren",
+    "label": "BX-32ZW",
+    "manufacturer": "Climax Technology, Ltd."
+  },
+  "0x018e:0x0002:0x0011": {
+    "description": "Bellbox",
+    "label": "BX-35ZW",
+    "manufacturer": "Climax Technology, Ltd."
+  },
+  "0x018e:0x0003:0x0001": {
+    "description": "Smoke Detector",
+    "label": "SD-8ZW",
+    "manufacturer": "Climax Technology, Ltd."
+  },
+  "0x018e:0x0003:0x0002": {
+    "description": "Heat Detector",
+    "label": "HD-9ZW",
+    "manufacturer": "Climax Technology, Ltd."
+  },
+  "0x018e:0x0003:0x0003": {
+    "description": "Water Sensor",
+    "label": "WS-15ZW",
+    "manufacturer": "Climax Technology, Ltd."
+  },
+  "0x018e:0x0003:0x0004": {
+    "description": "Smoke Detector",
+    "label": "SD-16ZW",
+    "manufacturer": "Climax Technology, Ltd."
+  },
+  "0x018e:0x0003:0x0009": {
+    "description": "Carbon Monoxide Detector",
+    "label": "CO-8ZW",
+    "manufacturer": "Climax Technology, Ltd."
+  },
+  "0x018e:0x0003:0x000e": {
+    "description": "Acoustic Glass Break Detector",
+    "label": "ACGS-23ZW",
+    "manufacturer": "Climax Technology, Ltd."
+  },
+  "0x018e:0x0003:0x0012": {
+    "description": "Water Leakage Sensor",
+    "label": "WLS-23-ZW",
+    "manufacturer": "Climax Technology, Ltd."
+  },
+  "0x018e:0x0003:0x0014": {
+    "description": "Smoke and Carbon Monoxide Detector",
+    "label": "SDCO",
+    "manufacturer": "Climax Technology, Ltd."
+  },
+  "0x018e:0x0003:0x0015": {
+    "description": "Smoke and Carbon Monoxide Detector",
+    "label": "SDCO",
+    "manufacturer": "Climax Technology, Ltd."
+  },
+  "0x018e:0x0003:0x0017": {
+    "description": "Smoke Detector",
+    "label": "SD-29",
+    "manufacturer": "Climax Technology, Ltd."
+  },
+  "0x018e:0x0003:0x0018": {
+    "description": "Smoke Detector",
+    "label": "SD-29",
+    "manufacturer": "Climax Technology, Ltd."
+  },
+  "0x018e:0x0004:0x0001": {
+    "description": "Power Switch Series",
+    "label": "PSS-29ZW",
+    "manufacturer": "Climax Technology, Ltd."
+  },
+  "0x018e:0x0004:0x0002": {
+    "description": "",
+    "label": "PSM-29ZW",
+    "manufacturer": "Climax Technology, Ltd."
+  },
+  "0x018e:0x0004:0x0003": {
+    "description": "DIN Rail Power Switch Meter",
+    "label": "PSM-DIN2-ZW",
+    "manufacturer": "Climax Technology, Ltd."
+  },
+  "0x018e:0x0004:0x0005": {
+    "description": "Shutter Control",
+    "label": "S-2ZW",
+    "manufacturer": "Climax Technology, Ltd."
+  },
+  "0x018e:0x0004:0x000c": {
+    "description": "Energy Meter",
+    "label": "EMD-1ZW",
+    "manufacturer": "Climax Technology, Ltd."
+  },
+  "0x018e:0x0004:0x000f": {
+    "description": "Z-Wave Router / USB Power Adaptor",
+    "label": "RMB-35ZW",
+    "manufacturer": "Climax Technology, Ltd."
+  },
+  "0x018e:0x0004:0x0013": {
+    "description": "DIN Rail Power Switch Meter",
+    "label": "PSM-DIN3-ZW",
+    "manufacturer": "Climax Technology, Ltd."
+  },
+  "0x018e:0x0004:0x0017": {
+    "description": "Luminance Meter",
+    "label": "LM-1ZW",
+    "manufacturer": "Climax Technology, Ltd."
+  },
+  "0x018e:0x0004:0x001d": {
+    "description": "Clamp Meter",
+    "label": "CLMT-1ZW",
+    "manufacturer": "Climax Technology, Ltd."
+  },
+  "0x018f:0x0100:0x0101": {
+    "description": "Secure Wall Controller",
+    "label": "ZME_WALLC-S",
+    "manufacturer": "Focal Point Ltd."
+  },
+  "0x0190:0x0001:0x0001": {
+    "description": "Alarm.com Smart Thermostat",
+    "label": "ADC-T 2000",
+    "manufacturer": "Building 36 Technologies"
+  },
+  "0x0190:0x0003:0x0001": {
+    "description": "Temperature Sensor",
+    "label": "ADC-S2000-T-RA",
+    "manufacturer": "Building 36 Technologies"
+  },
+  "0x0193:0x0001:0x0001": {
+    "description": "Universal Devices ISY-994i ZW",
+    "label": "ISY-994ZW",
+    "manufacturer": "Universal Devices, Inc"
+  },
+  "0x0193:0x0001:0x0002": {
+    "description": "Universal Devices ISY-994i ZW",
+    "label": "ISY-994ZW",
+    "manufacturer": "Universal Devices, Inc"
+  },
+  "0x0193:0x0001:0x0006": {
+    "description": "ISY-994 IR Pro Z-Wave/Insteon/X10",
+    "label": "ISY-994 ZW+/IR PRO",
+    "manufacturer": "Universal Devices, Inc"
+  },
+  "0x0193:0x0001:0x0007": {
+    "description": "ISY-994 IR Pro Z-Wave/Insteon/X10",
+    "label": "ISY-994 ZW+/IR PRO",
+    "manufacturer": "Universal Devices, Inc"
+  },
+  "0x0193:0x0001:0x0008": {
+    "description": "ISY-994 Zigbee/Z-Wave/Pro",
+    "label": "ISY-994 ZW+/ZS PRO",
+    "manufacturer": "Universal Devices, Inc"
+  },
+  "0x0193:0x0001:0x000a": {
+    "description": "ISY-994 Zigbee/Z-Wave/Pro",
+    "label": "ISY-994 ZW+/ZS PRO",
+    "manufacturer": "Universal Devices, Inc"
+  },
+  "0x0194:0x0001:0x0001": {
+    "description": "CLIQ.mini Controller",
+    "label": "CLIQ-MOSM-10",
+    "manufacturer": "Clare Controls"
+  },
+  "0x0195:0x0001:0x0001": {
+    "description": "MyAlert",
+    "label": "MYALERT001",
+    "manufacturer": "M2M Solution"
+  },
+  "0x0196:0x00b7:0x0097": {
+    "description": "Touch screen wall switch",
+    "label": "BrightSwitch",
+    "manufacturer": "Bellatrix Systems, Inc."
+  },
+  "0x0198:0x0003:0x0001": {
+    "description": "Voyager",
+    "label": "T3700 / T3800 / T3900 / T4700 / T4800 / T4900",
+    "manufacturer": "Venstar Inc."
+  },
+  "0x0199:0x0001:0x0001": {
+    "description": "Gemalto Multi Access Gateway",
+    "label": "300115",
+    "manufacturer": "Wireless Maingate AB"
+  },
+  "0x019a:0x0003:0x0003": {
+    "description": "Strips-MaZw",
+    "label": "11-01-011",
+    "manufacturer": "Sensative AB"
+  },
+  "0x019a:0x0003:0x000a": {
+    "description": "Strips Comfort/Drips Multisensor",
+    "label": "11 02 011",
+    "manufacturer": "Sensative AB"
+  },
+  "0x019a:0x0004:0x0004": {
+    "description": "Strips Guard 700",
+    "label": "11-01-021",
+    "manufacturer": "Sensative AB"
+  },
+  "0x019b:0x0001:0x0001": {
+    "description": "ZWave Thermostat",
+    "label": "TF016",
+    "manufacturer": "ThermoFloor"
+  },
+  "0x019b:0x0003:0x000d": {
+    "description": "Wired Smoke Detector",
+    "label": "Z-Smoke 230V",
+    "manufacturer": "Heatit"
+  },
+  "0x019b:0x0003:0x0201": {
+    "description": "ZWave Thermostat",
+    "label": "TF016",
+    "manufacturer": "ThermoFloor"
+  },
+  "0x019b:0x0003:0x0202": {
+    "description": "Floor thermostat",
+    "label": "Heatit Z-TRM 2",
+    "manufacturer": "ThermoFloor"
+  },
+  "0x019b:0x0003:0x0203": {
+    "description": "Floor thermostat",
+    "label": "Heatit Z-TRM3",
+    "manufacturer": "ThermoFloor"
+  },
+  "0x019b:0x0003:0x0208": {
+    "description": "Multipurpose relay",
+    "label": "Z-RELAY",
+    "manufacturer": "Heatit"
+  },
+  "0x019b:0x0003:0x020a": {
+    "description": "Relay control",
+    "label": "Z Water",
+    "manufacturer": "Heatit"
+  },
+  "0x019b:0x0003:0x2200": {
+    "description": "Knob Smart Dimmer",
+    "label": "HeatIt ZDim",
+    "manufacturer": "ThermoFloor"
+  },
+  "0x019b:0x0003:0x3600": {
+    "description": "Z-Wave Range Extender",
+    "label": "Z-Repeater",
+    "manufacturer": "Heatit"
+  },
+  "0x019b:0x0003:0x3601": {
+    "description": "Wired Smoke Detector",
+    "label": "Z-Smoke 230V",
+    "manufacturer": "Heatit"
+  },
+  "0x019b:0x0003:0x3602": {
+    "description": "Wireless Smoke Detector",
+    "label": "Z-Smoke Battery",
+    "manufacturer": "Heatit"
+  },
+  "0x019b:0x0004:0x0204": {
+    "description": "Battery operated thermostat",
+    "label": "Z-Temp2",
+    "manufacturer": "ThermoFloor AS"
+  },
+  "0x019b:0x0300:0xa305": {
+    "description": "Wall Mounted Switch",
+    "label": "Z Push Button 8",
+    "manufacturer": "Heatit"
+  },
+  "0x019c:0x0001:0x0001": {
+    "description": "PowerMaster-360",
+    "label": "PM-360",
+    "manufacturer": "Amdocs"
+  },
+  "0x019d:0x0002:0x0001": {
+    "description": "Mobilus Tubular Motor",
+    "label": "EZRS",
+    "manufacturer": "MOBILUS MOTOR Sp\u00f3\u0142ka z o.o."
+  },
+  "0x019d:0x0003:0x0001": {
+    "description": "mob.iq [rg3+]",
+    "label": "MOB.IQ [RG3+]",
+    "manufacturer": "MOBILUS MOTOR Sp\u00f3\u0142ka z o.o."
+  },
+  "0x019d:0x0003:0x0010": {
+    "description": "Mobilus Tubular Motor",
+    "label": "EZRS",
+    "manufacturer": "MOBILUS MOTOR Sp\u00f3\u0142ka z o.o."
+  },
+  "0x019e:0x0001:0x0001": {
+    "description": "Multiradio server for home automation with optional cloud connectivitiy",
+    "label": "Wibutler Pro",
+    "manufacturer": "iEXERGY GmbH"
+  },
+  "0x019f:0x0001:0x0001": {
+    "description": "Smartee",
+    "label": "SM2001",
+    "manufacturer": "Webee Life"
+  },
+  "0x0200:0x0001:0x0001": {
+    "description": "Xuan",
+    "label": "STACK BOX",
+    "manufacturer": "Cloud Media"
+  },
+  "0x0200:0x0003:0x0002": {
+    "description": "Motion Sensor",
+    "label": "A803N",
+    "manufacturer": "Cloud Media"
+  },
+  "0x0201:0x0003:0x0016": {
+    "description": "Samsung Connect Home Pro",
+    "label": "ET-WV530",
+    "manufacturer": "Samsung Electronics Co., Ltd."
+  },
+  "0x0201:0x0003:0x0017": {
+    "description": "SAMSUNG Connect Home",
+    "label": "ET-WV520",
+    "manufacturer": "Samsung Electronics Co., Ltd."
+  },
+  "0x0201:0x0003:0x0018": {
+    "description": "Samsung Connect Home Pro",
+    "label": "ET-WV532",
+    "manufacturer": "Samsung Electronics Co., Ltd."
+  },
+  "0x0201:0x0003:0x0019": {
+    "description": "SAMSUNG Connect Home",
+    "label": "ET-WV522",
+    "manufacturer": "Samsung Electronics Co., Ltd."
+  },
+  "0x0201:0x0003:0x001b": {
+    "description": "Samsung Connect Home Pro",
+    "label": "ET-WV531",
+    "manufacturer": "Samsung Electronics Co., Ltd."
+  },
+  "0x0201:0x0003:0x001d": {
+    "description": "Samsung Connect Home Pro",
+    "label": "ET-WV533",
+    "manufacturer": "Samsung Electronics Co., Ltd."
+  },
+  "0x0201:0x0003:0x001e": {
+    "description": "SmartThings Wifi",
+    "label": "ET-WV523",
+    "manufacturer": "Samsung Electronics Co., Ltd."
+  },
+  "0x0201:0x0003:0x0021": {
+    "description": "Samsung Connect Home Pro",
+    "label": "ET-WV531",
+    "manufacturer": "Samsung Electronics Co., Ltd."
+  },
+  "0x0201:0x0003:0x0022": {
+    "description": "SAMSUNG Connect Home",
+    "label": "ET-WV521",
+    "manufacturer": "Samsung Electronics Co., Ltd."
+  },
+  "0x0201:0x0003:0x0023": {
+    "description": "SmartThings Wifi Pro",
+    "label": "ET-WV535",
+    "manufacturer": "Samsung Electronics Co., Ltd."
+  },
+  "0x0201:0x0003:0x0024": {
+    "description": "SmartThings Wifi",
+    "label": "ET-WV525",
+    "manufacturer": "Samsung Electronics Co., Ltd."
+  },
+  "0x0201:0x0003:0x0025": {
+    "description": "SmartThings Wifi",
+    "label": "ET-WV525",
+    "manufacturer": "Samsung Electronics Co., Ltd."
+  },
+  "0x0201:0x0003:0x0033": {
+    "description": "SmartThings Wifi",
+    "label": "ET-WV525",
+    "manufacturer": "Samsung Electronics Co., Ltd."
+  },
+  "0x0201:0x0008:0x0026": {
+    "description": "Samsung Galaxy Home",
+    "label": "SM-V510",
+    "manufacturer": "Samsung Electronics Co., Ltd."
+  },
+  "0x0201:0x0008:0x0027": {
+    "description": "Samsung Galaxy Home",
+    "label": "SM-V510",
+    "manufacturer": "Samsung Electronics Co., Ltd."
+  },
+  "0x0202:0x0200:0x0000": {
+    "description": "Monoprice, P/N , Garage Detector",
+    "label": "11987",
+    "manufacturer": "Monoprice"
+  },
+  "0x0202:0x2001:0x0102": {
+    "description": "Door Window Sensor",
+    "label": "10795",
+    "manufacturer": "Monoprice"
+  },
+  "0x0202:0x2002:0x0202": {
+    "description": "Monoprice, P/N , PIR Motion Sensor",
+    "label": "10796",
+    "manufacturer": "Monoprice"
+  },
+  "0x0202:0x2006:0x0621": {
+    "description": "Monoprice, P/N , Door Lock",
+    "label": "10798",
+    "manufacturer": "Monoprice"
+  },
+  "0x0202:0x2007:0x0703": {
+    "description": "Monoprice, P/N , Plug-In Switch",
+    "label": "11995",
+    "manufacturer": "Monoprice"
+  },
+  "0x0202:0x2008:0x0803": {
+    "description": "Monoprice, P/N , Plug-In Dimmer",
+    "label": "11994",
+    "manufacturer": "Monoprice"
+  },
+  "0x0207:0x0027:0x0100": {
+    "description": "Drapery hardware",
+    "label": "Shuttle S/L",
+    "manufacturer": "Forest Group Nederland B.V"
+  },
+  "0x0208:0x0003:0x0300": {
+    "description": "Siterwell eyesonsor",
+    "label": "SW es01",
+    "manufacturer": "HANK Electronics Ltd."
+  },
+  "0x0208:0x0100:0x0004": {
+    "description": "HKZW-RGB01-V1.0",
+    "label": "RGB bulb",
+    "manufacturer": "HANK Electronics Ltd."
+  },
+  "0x0208:0x0100:0x0007": {
+    "description": "HKZW",
+    "label": "ACC01",
+    "manufacturer": "HANK Electronics Ltd."
+  },
+  "0x0208:0x0100:0x000a": {
+    "description": "Smart Plug",
+    "label": "HKZW-SO05",
+    "manufacturer": "HANK Electronics Ltd."
+  },
+  "0x0208:0x0101:0x0004": {
+    "description": "HKZW-RGB01-V1.0",
+    "label": "RGB bulb",
+    "manufacturer": "HANK Electronics Ltd."
+  },
+  "0x0208:0x0101:0x0005": {
+    "description": "Smart Plug with two USB ports",
+    "label": "HKZW-SO01",
+    "manufacturer": "HANK Electronics Ltd."
+  },
+  "0x0208:0x0101:0x000a": {
+    "description": "Smart Plug",
+    "label": "HKZW_SO03",
+    "manufacturer": "HANK Electronics Ltd."
+  },
+  "0x0208:0x0200:0x0008": {
+    "description": "Door and Window Sensor",
+    "label": "DWS01",
+    "manufacturer": "HANK Electronics Ltd."
+  },
+  "0x0208:0x0200:0x0009": {
+    "description": "One-key Scene Controller",
+    "label": "SCN01",
+    "manufacturer": "HANK Electronics Ltd."
+  },
+  "0x0208:0x0200:0x000b": {
+    "description": "Four-key Scene Controller",
+    "label": "SCN04",
+    "manufacturer": "HANK Electronics Ltd."
+  },
+  "0x0208:0x0200:0x000f": {
+    "description": "Flood Sensor FLD01",
+    "label": "HKZW_FLD01",
+    "manufacturer": "HANK Electronics Ltd."
+  },
+  "0x0208:0x0200:0x0012": {
+    "description": "Motion Sensor",
+    "label": "HKZW_MS02",
+    "manufacturer": "HANK Electronics Ltd."
+  },
+  "0x0208:0x0201:0x0006": {
+    "description": "Multisensor",
+    "label": "HKZW_MS01",
+    "manufacturer": "HANK Electronics Ltd."
+  },
+  "0x0208:0x0201:0x0008": {
+    "description": "Door and Window Sensor",
+    "label": "DWS01",
+    "manufacturer": "HANK Electronics Ltd."
+  },
+  "0x0208:0x0201:0x0009": {
+    "description": "One-key Scene Controller",
+    "label": "SCN01",
+    "manufacturer": "HANK Electronics Ltd."
+  },
+  "0x0208:0x0201:0x000b": {
+    "description": "Four-key Scene Controller",
+    "label": "SCN04",
+    "manufacturer": "HANK Electronics Ltd."
+  },
+  "0x0208:0x0201:0x000f": {
+    "description": "Flood Sensor FLD01",
+    "label": "HKZW_FLD01",
+    "manufacturer": "HANK Electronics Ltd."
+  },
+  "0x0208:0x0201:0x0012": {
+    "description": "Motion Sensor",
+    "label": "HKZW_MS02",
+    "manufacturer": "HANK Electronics Ltd."
+  },
+  "0x0208:0x0208:0x0101": {
+    "description": "Smart Plug with two USB ports",
+    "label": "PID15654",
+    "manufacturer": "HANK Electronics Ltd."
+  },
+  "0x0208:0x0300:0x0012": {
+    "description": "Motion Sensor",
+    "label": "HKZW_MS02",
+    "manufacturer": "HANK Electronics Ltd."
+  },
+  "0x020e:0x4754:0x3038": {
+    "description": "Smart LED Light",
+    "label": "DTA19",
+    "manufacturer": "Domitech Products, LLC"
+  },
+  "0x020e:0x4c42:0x3133": {
+    "description": "Smart LED Light Bulb",
+    "label": "ZRKSW",
+    "manufacturer": "Domitech Products, LLC"
+  },
+  "0x020e:0x4c42:0x3134": {
+    "description": "Smart LED Light",
+    "label": "DTA19",
+    "manufacturer": "Domitech Products, LLC"
+  },
+  "0x020e:0x4c42:0x3135": {
+    "description": "Smart LED Light",
+    "label": "DTA19",
+    "manufacturer": "Domitech Products, LLC"
+  },
+  "0x0212:0x1000:0x1000": {
+    "description": "Digital Door Lock",
+    "label": "A20-SH (GDA-A2E6B-K0)",
+    "manufacturer": "GATEMAN"
+  },
+  "0x0212:0xc600:0x0004": {
+    "description": "Digital Door Lock",
+    "label": "A200-CH (GDM-M2D6D-K0)",
+    "manufacturer": "GATEMAN"
+  },
+  "0x0212:0xc601:0x0001": {
+    "description": "",
+    "label": "R200-CH",
+    "manufacturer": "iRevo"
+  },
+  "0x0214:0x0002:0x0001": {
+    "description": "Door/Window Sensor",
+    "label": "IM-20",
+    "manufacturer": "Kaipule Technology Co., Ltd."
+  },
+  "0x0214:0x0002:0x0002": {
+    "description": "Smoke Sensor",
+    "label": "ES-61",
+    "manufacturer": "Kaipule Technology Co., Ltd."
+  },
+  "0x0214:0x0003:0x0001": {
+    "description": "Door/Window Sensor",
+    "label": "IM-20",
+    "manufacturer": "Kaipule Technology Co., Ltd."
+  },
+  "0x0214:0x0003:0x0002": {
+    "description": "PIR Sensor",
+    "label": "DP-32 / IX-30 / IX-32",
+    "manufacturer": "Kaipule Technology Co., Ltd."
+  },
+  "0x0214:0x0004:0x0001": {
+    "description": "Smoke Sensor",
+    "label": "ES-61",
+    "manufacturer": "Kaipule Technology Co., Ltd."
+  },
+  "0x0217:0x0800:0x0001": {
+    "description": "Westinghouse RTS-Z",
+    "label": "8001",
+    "manufacturer": "Strattec Advanced Logic, LLC"
+  },
+  "0x0217:0x0800:0x0002": {
+    "description": "Westinghouse RTS-Z-AU",
+    "label": "8002",
+    "manufacturer": "Strattec Advanced Logic, LLC"
+  },
+  "0x0217:0x0900:0x0001": {
+    "description": "Westinghouse RTS-PZ",
+    "label": "9001",
+    "manufacturer": "Strattec Advanced Logic, LLC"
+  },
+  "0x0217:0x0900:0x0002": {
+    "description": "Westinghouse RTS-PZ-AU",
+    "label": "9002",
+    "manufacturer": "Strattec Advanced Logic, LLC"
+  },
+  "0x021c:0x1010:0x1008": {
+    "description": "1 Gang Wall Switch",
+    "label": "J1506",
+    "manufacturer": "Shenzhen iSurpass Technology Co. , Ltd."
+  },
+  "0x021c:0x5000:0x1000": {
+    "description": "Door Lock with Handle",
+    "label": "DL9101V",
+    "manufacturer": "Shenzhen iSurpass Technology Co. , Ltd."
+  },
+  "0x021c:0x5010:0x1001": {
+    "description": "Smart Door Lock",
+    "label": "ILOCK15",
+    "manufacturer": "Shenzhen iSurpass Technology Co. , Ltd."
+  },
+  "0x021c:0x634b:0x504c": {
+    "description": "Smart lock",
+    "label": "iLock",
+    "manufacturer": "Shenzhen iSurpass Technology Co. , Ltd."
+  },
+  "0x021c:0x8000:0x1000": {
+    "description": "Door Sensor",
+    "label": "J1504",
+    "manufacturer": "Shenzhen iSurpass Technology Co. , Ltd."
+  },
+  "0x021c:0x8002:0x1000": {
+    "description": "Carbon monoxide detector, smoke detector",
+    "label": "Smoke Detector",
+    "manufacturer": "Shenzhen iSurpass Technology Co. , Ltd."
+  },
+  "0x021c:0x8004:0x1000": {
+    "description": "Domux Water Leakage Sensor",
+    "label": "DX1WL-Z",
+    "manufacturer": "Shenzhen iSurpass Technology Co. , Ltd."
+  },
+  "0x021c:0x8011:0x1000": {
+    "description": "Motion Sensor",
+    "label": "J1505",
+    "manufacturer": "Shenzhen iSurpass Technology Co. , Ltd."
+  },
+  "0x021d:0x0003:0x0001": {
+    "description": "Touchscreen Digital Deadbolt",
+    "label": "DB2",
+    "manufacturer": "Shenzhen Kaadas Intelligent Technology Co., Ltd."
+  },
+  "0x021d:0x0003:0x0002": {
+    "description": "Digital Deadbolt Lock",
+    "label": "DB1",
+    "manufacturer": "Shenzhen Kaadas Intelligent Technology Co., Ltd."
+  },
+  "0x021d:0x0003:0x0003": {
+    "description": "Digital Mortise Door Lock",
+    "label": "HU03",
+    "manufacturer": "Shenzhen Kaadas Intelligent Technology Co., Ltd."
+  },
+  "0x021f:0x0001:0x0001": {
+    "description": "Hub",
+    "label": "DMGW1",
+    "manufacturer": "Elexa Consumer Products Inc."
+  },
+  "0x021f:0x0003:0x0002": {
+    "description": "Dome Water Main Shut Off",
+    "label": "DMWV1",
+    "manufacturer": "Elexa Consumer Products Inc."
+  },
+  "0x021f:0x0003:0x0083": {
+    "description": "Dome Z-Wave Plus Motion Detector with Light Sensor and Flexible Magnetic Mount",
+    "label": "DMMS1",
+    "manufacturer": "Elexa Consumer Products Inc."
+  },
+  "0x021f:0x0003:0x0085": {
+    "description": "Dome Leak Sensor",
+    "label": "DMWS1",
+    "manufacturer": "Elexa Consumer Products Inc."
+  },
+  "0x021f:0x0003:0x0087": {
+    "description": "Dome On/Off zwave wall plug for controlling small appliances and lights.",
+    "label": "DMOF1",
+    "manufacturer": "Elexa Consumer Products Inc."
+  },
+  "0x021f:0x0003:0x0088": {
+    "description": "Dome Wireless Siren",
+    "label": "DMS01",
+    "manufacturer": "Elexa Consumer Products Inc."
+  },
+  "0x021f:0x0003:0x0101": {
+    "description": "Dome door & window sensor",
+    "label": "DMWD1",
+    "manufacturer": "Elexa Consumer Products Inc."
+  },
+  "0x021f:0x0003:0x0104": {
+    "description": "Dome Battery powered Z-Wave Plus enabled mousetrap",
+    "label": "DMMZ1",
+    "manufacturer": "Elexa Consumer Products Inc."
+  },
+  "0x021f:0x0003:0x0108": {
+    "description": "Range Extender",
+    "label": "DMEX1",
+    "manufacturer": "Dome"
+  },
+  "0x021f:0x0003:0x0201": {
+    "description": "Dome Window and Door Sensor Pro",
+    "label": "DMDP1",
+    "manufacturer": "Elexa Consumer Products Inc."
+  },
+  "0x0221:0x0003:0x0003": {
+    "description": "DOOR/WINDOW SENSOR",
+    "label": "HT01-609I",
+    "manufacturer": "HOSEOTELNET"
+  },
+  "0x0222:0x0010:0x0010": {
+    "description": "Talk-Z",
+    "label": "MPU100ZW",
+    "manufacturer": "MCT CO., Ltd."
+  },
+  "0x0223:0x0001:0x0001": {
+    "description": "Schwaiger Home Gateway",
+    "label": "HA101",
+    "manufacturer": "DTV Research Unipessoal, Lda"
+  },
+  "0x0223:0x0001:0x0002": {
+    "description": "TELE System GetMagic",
+    "label": "G513V1",
+    "manufacturer": "DTV Research Unipessoal, Lda"
+  },
+  "0x0224:0x0001:0x0001": {
+    "description": "LifeShield Base",
+    "label": "S30",
+    "manufacturer": "LifeShield, LLC"
+  },
+  "0x0224:0x0001:0x0002": {
+    "description": "Smart Home Hub",
+    "label": "S40LR0-01",
+    "manufacturer": "LifeShield, LLC"
+  },
+  "0x0227:0x0100:0x0100": {
+    "description": "Data Collecting Module NEVOTON",
+    "label": "DCM-5.1.1-Z",
+    "manufacturer": "NEVOTON"
+  },
+  "0x022a:0x0100:0x0100": {
+    "description": "TIMEVALVE SMART",
+    "label": "HY-15-05",
+    "manufacturer": "TIMEVALVE, Inc."
+  },
+  "0x022c:0x0003:0x0001": {
+    "description": "Open Sensor",
+    "label": "OSR-01",
+    "manufacturer": "LG U+"
+  },
+  "0x022c:0x0003:0x0002": {
+    "description": "Open Sensor",
+    "label": "SA08",
+    "manufacturer": "Remote Solution"
+  },
+  "0x022c:0x0060:0x0001": {
+    "description": "Open Sensor",
+    "label": "OSR-02",
+    "manufacturer": "LG U+"
+  },
+  "0x022d:0x0100:0x0001": {
+    "description": "IoT Hub",
+    "label": "MC01-507L",
+    "manufacturer": "Mercury Corporation"
+  },
+  "0x022d:0x0100:0x0301": {
+    "description": "IoT Home Manager Hub(LTE Type)",
+    "label": "MC03-611ZM",
+    "manufacturer": "Mercury Corporation"
+  },
+  "0x022d:0x0401:0x0101": {
+    "description": "Door Sensor",
+    "label": "MC01-1702OPS",
+    "manufacturer": "Mercury Corporation"
+  },
+  "0x022e:0x0003:0x0001": {
+    "description": "Doorlock Control Module for Samsung Locks",
+    "label": "hmdm100",
+    "manufacturer": "Samsung SDS"
+  },
+  "0x022e:0x0003:0x0003": {
+    "description": "SMART BUTTON",
+    "label": "SHP-TB100Z",
+    "manufacturer": "Samsung SDS"
+  },
+  "0x022e:0x0004:0x0004": {
+    "description": "Window/Door Sensor",
+    "label": "SHP-SB100Z",
+    "manufacturer": "Samsung SDS"
+  },
+  "0x022e:0x0005:0x0005": {
+    "description": "Motion sensor",
+    "label": "SHP-SR100Z",
+    "manufacturer": "Samsung SDS"
+  },
+  "0x022e:0x0006:0x0006": {
+    "description": "Gradient Sensor",
+    "label": "SHP-SG100Z",
+    "manufacturer": "Samsung SDS"
+  },
+  "0x022e:0x0007:0x0007": {
+    "description": "IoT Hub",
+    "label": "SHP-GS100M",
+    "manufacturer": "Samsung SDS"
+  },
+  "0x022e:0x0007:0x0008": {
+    "description": "Home Security Pad",
+    "label": "SHP-HA502M",
+    "manufacturer": "Samsung SDS"
+  },
+  "0x0230:0x0003:0x0001": {
+    "description": "Z-Wave Lock",
+    "label": "IDL-101",
+    "manufacturer": "Alphonsus Tech"
+  },
+  "0x0232:0x0001:0x0001": {
+    "description": "Smart Brain\u2122",
+    "label": "MIT-SB100",
+    "manufacturer": "MODACOM CO., Ltd."
+  },
+  "0x0233:0x0049:0x0001": {
+    "description": "U+ Switch",
+    "label": "SSE-301",
+    "manufacturer": "eZEX Corporation"
+  },
+  "0x0233:0x004c:0x0001": {
+    "description": "U+ Switch",
+    "label": "SSE-302",
+    "manufacturer": "eZEX Corporation"
+  },
+  "0x0233:0x004c:0x0002": {
+    "description": "U+ Switch",
+    "label": "SSE-303",
+    "manufacturer": "eZEX Corporation"
+  },
+  "0x0234:0x0002:0x010a": {
+    "description": "FUGA Wall 4-way Switch with LED + Relay",
+    "label": "ZHC5010",
+    "manufacturer": "Logic Group"
+  },
+  "0x0234:0x0003:0x010a": {
+    "description": "FUGA Wall 4-way Switch with LED + Relay",
+    "label": "ZHC5010",
+    "manufacturer": "Logic Group"
+  },
+  "0x0234:0x0003:0x010c": {
+    "description": "Heatit Z-Scene Controller Push button 6-gang",
+    "label": " ZHC5002",
+    "manufacturer": "Logic Group"
+  },
+  "0x0234:0x0003:0x010d": {
+    "description": "DIN-rail module with 10 digital ouputs and 4 digital inputs",
+    "label": "LHC5020",
+    "manufacturer": "Logic Group"
+  },
+  "0x0234:0x0003:0x0111": {
+    "description": "DIN Mount Multiple Actuator Controller for Floor Heating",
+    "label": "LHC5031",
+    "manufacturer": "Logic Group"
+  },
+  "0x0234:0x0003:0x0112": {
+    "description": "6 relay switches and 6 digital inputs module for DIN rail",
+    "label": "ZIF5028 / HeatIt Z-DIN 616",
+    "manufacturer": "Logic Group"
+  },
+  "0x0234:0x0003:0x0121": {
+    "description": "MATRIX Switch with Dimmer and Backlight",
+    "label": "ZDB5100",
+    "manufacturer": "Logic Group"
+  },
+  "0x0236:0x0003:0x0002": {
+    "description": "BANDI",
+    "label": "BDS-301 Z",
+    "manufacturer": "Bandi Comm Tech Inc."
+  },
+  "0x0238:0x0003:0x0004": {
+    "description": "Milan Infoway",
+    "label": "NLMN11",
+    "manufacturer": "Milanity, Inc."
+  },
+  "0x0239:0x0001:0x0001": {
+    "description": "4000W Thermostat",
+    "label": "STZW402+",
+    "manufacturer": "Stelpro"
+  },
+  "0x023a:0x0001:0x0001": {
+    "description": "LED Light",
+    "label": "KHEZ-0001",
+    "manufacturer": "KUMHO ELECTRIC, INC"
+  },
+  "0x023b:0x0001:0x0001": {
+    "description": "Multiple RF Home Gateway",
+    "label": "F4-ZB-ZWE",
+    "manufacturer": "ROC-Connect, Inc."
+  },
+  "0x023c:0x0001:0x0001": {
+    "description": "The Quickbox - Home Edition",
+    "label": "QBBIOZW",
+    "manufacturer": "SafeTech Products"
+  },
+  "0x023c:0x0001:0x0002": {
+    "description": "The Doorlock",
+    "label": "QLDLZW",
+    "manufacturer": "SafeTech Products"
+  },
+  "0x023d:0x0043:0x0001": {
+    "description": "IoT DoorCam",
+    "label": "DCH-01",
+    "manufacturer": "Honest Technology Co., Ltd."
+  },
+  "0x023f:0x0000:0x0025": {
+    "description": "EA-5 Entertainment and Automation Controller with US Z-Wave Module",
+    "label": "EA-5 / C4-ZWU",
+    "manufacturer": "Control4 Corporation"
+  },
+  "0x023f:0x0000:0x002a": {
+    "description": "EA-1 Entertainment and Automation Controller with US Z-Wave Module",
+    "label": "EA-1 / C4-ZWU",
+    "manufacturer": "Control4 Corporation"
+  },
+  "0x023f:0x0000:0x002b": {
+    "description": "EA-3 Entertainment and Automation Controller with US Z-Wave Module",
+    "label": "EA-3 / C4-ZWU",
+    "manufacturer": "Control4 Corporation"
+  },
+  "0x023f:0x0000:0x002c": {
+    "description": "EA-5 Entertainment and Automation Controller with US Z-Wave Module",
+    "label": "EA-5 / C4-ZWU",
+    "manufacturer": "Control4 Corporation"
+  },
+  "0x023f:0x0000:0x002d": {
+    "description": "CA-1 Control and Automation Controller with US Z-Wave Module",
+    "label": "CA-1 / C4-ZWU",
+    "manufacturer": "Control4 Corporation"
+  },
+  "0x0240:0x0001:0x0001": {
+    "description": "IZE Extender",
+    "label": "HOVISBOXSH",
+    "manufacturer": "Technicolor"
+  },
+  "0x0240:0x0002:0x0001": {
+    "description": "SmartHub",
+    "label": "MBHA10",
+    "manufacturer": "Technicolor"
+  },
+  "0x0241:0x0001:0x0001": {
+    "description": "NEEO Brain, EU",
+    "label": "6336-BRAIN-00008",
+    "manufacturer": "NEEO AG"
+  },
+  "0x0242:0x0003:0x0011": {
+    "description": "WTR-1000-11",
+    "label": "03110101",
+    "manufacturer": "Winytechnology"
+  },
+  "0x0242:0x0a02:0x0061": {
+    "description": "Sensor Input device (KASAIHOUCHIKIADAPTOR01)",
+    "label": "UFA01",
+    "manufacturer": "KDDI CORPORATION"
+  },
+  "0x0244:0xba5e:0x0001": {
+    "description": "Homey",
+    "label": "HOMEY",
+    "manufacturer": "Athom BV"
+  },
+  "0x0245:0x0003:0x0001": {
+    "description": "Metering Plug switching 16A",
+    "label": "PSC234ZW",
+    "manufacturer": "permundo GmbH"
+  },
+  "0x0245:0x0003:0x0002": {
+    "description": "Metering Relay Switch, 16A",
+    "label": "PSC132ZW",
+    "manufacturer": "permundo GmbH"
+  },
+  "0x0245:0x0003:0x0004": {
+    "description": "Shutter Controller",
+    "label": "PSC152ZW",
+    "manufacturer": "permundo GmbH"
+  },
+  "0x0246:0x0001:0x0001": {
+    "description": "Smart Plug",
+    "label": "3210-L",
+    "manufacturer": "CentraLite Systems, Inc"
+  },
+  "0x0248:0x0001:0x0001": {
+    "description": "coqon qbox",
+    "label": "CQNGATEV1",
+    "manufacturer": "neusta next GmbH & Co. KG"
+  },
+  "0x0248:0x0003:0x0001": {
+    "description": "Plug module",
+    "label": "PSMZ0001",
+    "manufacturer": "neusta next GmbH & Co. KG"
+  },
+  "0x0249:0x0002:0x0001": {
+    "description": "Smart Color Button",
+    "label": "PSR07",
+    "manufacturer": "WeBeHome"
+  },
+  "0x0249:0x0003:0x0001": {
+    "description": "Moving Blinds Art Andersen",
+    "label": "1.0",
+    "manufacturer": "Art Andersen"
+  },
+  "0x024a:0x0102:0x0304": {
+    "description": "Heimdall",
+    "label": "HEIMDALL",
+    "manufacturer": "BTSTAR(HK) TECHNOLOGY COMPANY Ltd."
+  },
+  "0x024b:0x0100:0x0001": {
+    "description": "EchoLife LS",
+    "label": "1015",
+    "manufacturer": "Huawei Technologies Co., Ltd."
+  },
+  "0x024b:0x0100:0x0010": {
+    "description": "EchoLife LS",
+    "label": "1015",
+    "manufacturer": "Huawei Technologies Co., Ltd."
+  },
+  "0x024c:0x0100:0x0100": {
+    "description": "Smart Gas Keeper",
+    "label": "HT-A10",
+    "manufacturer": "Gas Keeper"
+  },
+  "0x024c:0x0100:0x0101": {
+    "description": "Gas Detector",
+    "label": "HT-A20",
+    "manufacturer": "Hankook Gas Kiki CO., Ltd."
+  },
+  "0x024d:0x0001:0x0001": {
+    "description": "LiveConnect Center",
+    "label": "ZG-500-V1",
+    "manufacturer": "Z-works Inc."
+  },
+  "0x024d:0x0001:0x0002": {
+    "description": "Z-Works 3G Gateway",
+    "label": "ZG-501-V1",
+    "manufacturer": "Z-works Inc."
+  },
+  "0x024d:0x4761:0x0001": {
+    "description": "Lock Dectector",
+    "label": "DN3G6JA062",
+    "manufacturer": "Z-works Inc."
+  },
+  "0x024f:0x0003:0x1002": {
+    "description": "Multifunction Switch",
+    "label": "FMS01",
+    "manufacturer": "Smartly AS"
+  },
+  "0x024f:0x0003:0x1010": {
+    "description": "Standalone Relay 2-Pole",
+    "label": "AR2P",
+    "manufacturer": "SE Devices"
+  },
+  "0x024f:0x0003:0x1011": {
+    "description": "Standalone 1-10V Dimmer",
+    "label": "AD1-10V",
+    "manufacturer": "SE Devices"
+  },
+  "0x024f:0x0003:0x1012": {
+    "description": "Standalone Mosfet Dimmer",
+    "label": "AM",
+    "manufacturer": "SE Devices"
+  },
+  "0x024f:0x0003:0x1013": {
+    "description": "Standalone Relay 1-Pole",
+    "label": "AR1P",
+    "manufacturer": "SE Devices"
+  },
+  "0x0255:0x0001:0x0001": {
+    "description": "Z-Wave Interface Module",
+    "label": "ZW-9",
+    "manufacturer": "Remote Technologies Incorporated"
+  },
+  "0x0257:0x004d:0x0001": {
+    "description": "FESCO H2",
+    "label": "FCP-01",
+    "manufacturer": "PARATECH"
+  },
+  "0x0258:0x0003:0x0082": {
+    "description": "Door/Window Sensor",
+    "label": "NAS-DS01Z",
+    "manufacturer": "Shenzhen Neo Electronics Co., Ltd."
+  },
+  "0x0258:0x0003:0x0083": {
+    "description": "PIR Motion Sensor",
+    "label": "Motion Sensor",
+    "manufacturer": "Shenzhen Neo Electronics Co., Ltd."
+  },
+  "0x0258:0x0003:0x0085": {
+    "description": "Flood/water sensor",
+    "label": "Flood sensor",
+    "manufacturer": "Shenzhen Neo Electronics Co., Ltd."
+  },
+  "0x0258:0x0003:0x0087": {
+    "description": "Wall Plug Switch",
+    "label": "NAS-WR01Z",
+    "manufacturer": "Shenzhen Neo Electronics Co., Ltd."
+  },
+  "0x0258:0x0003:0x0088": {
+    "description": "Siren Alarm",
+    "label": "NAS-AB01Z",
+    "manufacturer": "Shenzhen Neo Electronics Co., Ltd."
+  },
+  "0x0258:0x0003:0x008b": {
+    "description": "Light Switch 2 Channel",
+    "label": "EU-2",
+    "manufacturer": "Shenzhen Neo Electronics Co., Ltd."
+  },
+  "0x0258:0x0003:0x008d": {
+    "description": "PIR Motion Sensor",
+    "label": "Motion Sensor",
+    "manufacturer": "Shenzhen Neo Electronics Co., Ltd."
+  },
+  "0x0258:0x0003:0x1082": {
+    "description": "Door/Window Sensor",
+    "label": "NAS-DS01Z",
+    "manufacturer": "Shenzhen Neo Electronics Co., Ltd."
+  },
+  "0x0258:0x0003:0x1083": {
+    "description": "PIR Motion Sensor",
+    "label": "Motion Sensor",
+    "manufacturer": "Shenzhen Neo Electronics Co., Ltd."
+  },
+  "0x0258:0x0003:0x1085": {
+    "description": "Flood/water sensor",
+    "label": "Flood sensor",
+    "manufacturer": "Shenzhen Neo Electronics Co., Ltd."
+  },
+  "0x0258:0x0003:0x1087": {
+    "description": "Wall Plug Switch",
+    "label": "NAS-WR01Z",
+    "manufacturer": "Shenzhen Neo Electronics Co., Ltd."
+  },
+  "0x0258:0x0003:0x1088": {
+    "description": "Siren Alarm",
+    "label": "NAS-AB01Z",
+    "manufacturer": "Shenzhen Neo Electronics Co., Ltd."
+  },
+  "0x0258:0x0003:0x108a": {
+    "description": "Z-Wave Remote for Scene selection and SOS button",
+    "label": "SOS/Remote Control",
+    "manufacturer": "Shenzhen Neo Electronics Co., Ltd."
+  },
+  "0x0258:0x0003:0x108b": {
+    "description": "Light Switch 2 Channel",
+    "label": "EU-2",
+    "manufacturer": "Shenzhen Neo Electronics Co., Ltd."
+  },
+  "0x0258:0x0003:0x108c": {
+    "description": "Light Switch 1 Channel",
+    "label": "EU-1",
+    "manufacturer": "Shenzhen Neo Electronics Co., Ltd."
+  },
+  "0x0258:0x0003:0x108d": {
+    "description": "PIR Motion Sensor with Temperature Sensor",
+    "label": "PD03Z",
+    "manufacturer": "Shenzhen Neo Electronics Co., Ltd."
+  },
+  "0x0258:0x0003:0x108f": {
+    "description": "SOS/Remote Control 1 Button",
+    "label": "NAS-RC03Z",
+    "manufacturer": "Shenzhen Neo Electronics Co., Ltd."
+  },
+  "0x0258:0x0003:0x1483": {
+    "description": "Wall Plug Switch",
+    "label": "NAS-WR01Z",
+    "manufacturer": "Shenzhen Neo Electronics Co., Ltd."
+  },
+  "0x0258:0x0003:0x2082": {
+    "description": "Door/Window Sensor",
+    "label": "NAS-DS01Z",
+    "manufacturer": "Shenzhen Neo Electronics Co., Ltd."
+  },
+  "0x0258:0x0003:0x2083": {
+    "description": "PIR Motion Sensor",
+    "label": "Motion Sensor",
+    "manufacturer": "Shenzhen Neo Electronics Co., Ltd."
+  },
+  "0x0258:0x0003:0x2085": {
+    "description": "Flood/water sensor",
+    "label": "Flood sensor",
+    "manufacturer": "Shenzhen Neo Electronics Co., Ltd."
+  },
+  "0x0258:0x0003:0x2087": {
+    "description": "Wall Plug Switch",
+    "label": "NAS-WR01Z",
+    "manufacturer": "Shenzhen Neo Electronics Co., Ltd."
+  },
+  "0x0258:0x0003:0x2088": {
+    "description": "Siren Alarm",
+    "label": "NAS-AB01Z",
+    "manufacturer": "Shenzhen Neo Electronics Co., Ltd."
+  },
+  "0x0258:0x0003:0x208b": {
+    "description": "Light Switch 2 Channel",
+    "label": "EU-2",
+    "manufacturer": "Shenzhen Neo Electronics Co., Ltd."
+  },
+  "0x0258:0x0003:0x208c": {
+    "description": "Light Switch 1 Channel",
+    "label": "EU-1",
+    "manufacturer": "Shenzhen Neo Electronics Co., Ltd."
+  },
+  "0x0258:0x0003:0x208d": {
+    "description": "PIR Motion Sensor with Temperature Sensor",
+    "label": "PD03Z",
+    "manufacturer": "Shenzhen Neo Electronics Co., Ltd."
+  },
+  "0x0258:0x0003:0x3082": {
+    "description": "Door/Window Sensor",
+    "label": "NAS-DS01Z",
+    "manufacturer": "Shenzhen Neo Electronics Co., Ltd."
+  },
+  "0x0258:0x0003:0x3083": {
+    "description": "Motion Sensor IN",
+    "label": "Motion Sensor IN",
+    "manufacturer": "Shenzhen Neo Electronics Co., Ltd."
+  },
+  "0x0258:0x0003:0x4082": {
+    "description": "Door/Window Sensor",
+    "label": "NAS-DS01Z",
+    "manufacturer": "Shenzhen Neo Electronics Co., Ltd."
+  },
+  "0x0258:0x0003:0x6082": {
+    "description": "Door/Window Sensor",
+    "label": "NAS-DS01Z",
+    "manufacturer": "Shenzhen Neo Electronics Co., Ltd."
+  },
+  "0x0258:0x0003:0x6088": {
+    "description": "Siren Alarm",
+    "label": "NAS-AB01Z",
+    "manufacturer": "Shenzhen Neo Electronics Co., Ltd."
+  },
+  "0x0258:0x0100:0x1027": {
+    "description": "Wall Plug Switch",
+    "label": "NAS-WR01ZE",
+    "manufacturer": "Shenzhen Neo Electronics Co., Ltd."
+  },
+  "0x0258:0x0200:0x1027": {
+    "description": "Wall Plug Switch",
+    "label": "NAS-WR01ZE",
+    "manufacturer": "Shenzhen Neo Electronics Co., Ltd."
+  },
+  "0x0258:0x0200:0x102b": {
+    "description": "Light Switch 3 Channel",
+    "label": "EU-3",
+    "manufacturer": "Shenzhen Neo Electronics Co., Ltd."
+  },
+  "0x0258:0x0200:0x102c": {
+    "description": "NEO Coolcam Roller Shutter - Curtain Switch - NAS-SC03ZE-2-T-V3",
+    "label": "NEO Coolcam Roller Shutter",
+    "manufacturer": "Shenzhen Neo Electronics Co., Ltd."
+  },
+  "0x0258:0x0200:0x1031": {
+    "description": "PIR Motion Sensor with Temperature Sensor",
+    "label": "PD03Z",
+    "manufacturer": "Shenzhen Neo Electronics Co., Ltd."
+  },
+  "0x0259:0x0003:0x0002": {
+    "description": "P-M-O",
+    "label": "RPB11647BS",
+    "manufacturer": "Starkoff"
+  },
+  "0x0259:0x0003:0x0022": {
+    "description": "PowerGate",
+    "label": "PG200",
+    "manufacturer": "Starkoff"
+  },
+  "0x025b:0x0001:0x0001": {
+    "description": "eZLO Controller",
+    "label": "EZ0001",
+    "manufacturer": "AdTrustMedia LLC dba: eZLO"
+  },
+  "0x025b:0x0002:0x0001": {
+    "description": "Worlds Smallest Hub",
+    "label": "ZL-100",
+    "manufacturer": "AdTrustMedia LLC dba: eZLO"
+  },
+  "0x025d:0x0100:0x0100": {
+    "description": "",
+    "label": "Da Vinci v9",
+    "manufacturer": "Avadesign Technology Co."
+  },
+  "0x025d:0x0200:0x0100": {
+    "description": "",
+    "label": "Da Vinci Switch Default",
+    "manufacturer": "Avadesign Technology Co."
+  },
+  "0x0260:0x0168:0x0168": {
+    "description": "Smart Door Sensor",
+    "label": "HS1DS-Z",
+    "manufacturer": "Shenzhen Heiman Technology Co., Ltd."
+  },
+  "0x0260:0x8001:0x1000": {
+    "description": "Smart Motion Sensor",
+    "label": "HS1MS-Z",
+    "manufacturer": "Shenzhen Heiman Technology Co., Ltd."
+  },
+  "0x0260:0x8001:0x1001": {
+    "description": "Smart Motion Sensor",
+    "label": "HS3MS-Z",
+    "manufacturer": "Shenzhen Heiman Technology Co., Ltd."
+  },
+  "0x0260:0x8002:0x1000": {
+    "description": "Smoke Detector",
+    "label": "HS1SA-Z",
+    "manufacturer": "Shenzhen Heiman Technology Co., Ltd."
+  },
+  "0x0260:0x8002:0x1001": {
+    "description": "Smart Smoke Sensor",
+    "label": "HS3SA-Z",
+    "manufacturer": "Shenzhen Heiman Technology Co., Ltd."
+  },
+  "0x0260:0x8003:0x1000": {
+    "description": "CH4 Gas Sensor",
+    "label": "DX1CG-Z",
+    "manufacturer": "Shenzhen Heiman Technology Co., Ltd."
+  },
+  "0x0260:0x8004:0x1000": {
+    "description": "Smart Water Leakage Sensor",
+    "label": "HS3WL-Z",
+    "manufacturer": "Shenzhen Heiman Technology Co., Ltd."
+  },
+  "0x0260:0x8005:0x1000": {
+    "description": "CO Detector",
+    "label": "HS1CA-Z",
+    "manufacturer": "Shenzhen Heiman Technology Co., Ltd."
+  },
+  "0x0260:0x8006:0x1000": {
+    "description": "Smart Metering Plug",
+    "label": "HS2SK-Z",
+    "manufacturer": "Shenzhen Heiman Technology Co., Ltd."
+  },
+  "0x0260:0x8007:0x1000": {
+    "description": "Temperature/Humidity Sensor",
+    "label": "HS1HT-Z",
+    "manufacturer": "Shenzhen Heiman Technology Co., Ltd."
+  },
+  "0x0260:0x8009:0x1000": {
+    "description": "Smart Siren",
+    "label": "HS2WD-Z",
+    "manufacturer": "Shenzhen Heiman Technology Co., Ltd."
+  },
+  "0x0260:0x8010:0x1000": {
+    "description": "Smart Switch",
+    "label": "HS2SW1A-Z",
+    "manufacturer": "Shenzhen Heiman Technology Co., Ltd."
+  },
+  "0x0260:0x8012:0x1000": {
+    "description": "Smart CO Alarm",
+    "label": "HM-723ESY-Z",
+    "manufacturer": "Shenzhen Heiman Technology Co., Ltd."
+  },
+  "0x0261:0x0101:0x0201": {
+    "description": "Wall plug smart switch",
+    "label": "WP-US-2/U2/1",
+    "manufacturer": "KOOL KONCEPTS"
+  },
+  "0x0262:0x0003:0x0001": {
+    "description": "TPD Z-Wave",
+    "label": "DBZF-3410",
+    "manufacturer": "Taiwan Fu Hsing Industrial Co., Ltd."
+  },
+  "0x0262:0x0004:0x0001": {
+    "description": "Electronic Z-Wave Deadbolt",
+    "label": "GB05DBF",
+    "manufacturer": "Taiwan Fu Hsing Industrial Co., Ltd."
+  },
+  "0x0265:0x0001:0x0001": {
+    "description": "Smart home camera gateway",
+    "label": "IC731Z",
+    "manufacturer": "StarVedia"
+  },
+  "0x0265:0x0001:0x0003": {
+    "description": "Megapixel Z-Wave IP Camera",
+    "label": "IC722Z",
+    "manufacturer": "StarVedia"
+  },
+  "0x0265:0x0001:0x0004": {
+    "description": "Smart Home Gateway",
+    "label": "G1",
+    "manufacturer": "StarVedia"
+  },
+  "0x0265:0x0001:0x0009": {
+    "description": "Doorbell Gateway",
+    "label": "D1",
+    "manufacturer": "StarVedia"
+  },
+  "0x0265:0x0002:0x0009": {
+    "description": "Doorbell Gateway",
+    "label": "D1",
+    "manufacturer": "StarVedia"
+  },
+  "0x0265:0x0003:0x0009": {
+    "description": "Doorbell Gateway",
+    "label": "D1",
+    "manufacturer": "StarVedia"
+  },
+  "0x0266:0x0001:0x0001": {
+    "description": "SiterOne",
+    "label": "STW-GS190",
+    "manufacturer": "Siterwell Technology HK Co., Ltd."
+  },
+  "0x0266:0x0003:0x0002": {
+    "description": "Power Plug",
+    "label": "SM_PZ710U",
+    "manufacturer": "Siterwell Technology HK Co., Ltd."
+  },
+  "0x0266:0x0004:0x0001": {
+    "description": "Wireless Water Leak Alarm",
+    "label": "GS156",
+    "manufacturer": "Siterwell Technology HK Co., Ltd."
+  },
+  "0x0266:0x0005:0x0001": {
+    "description": "Smoke Alarm Sensor",
+    "label": "GS559",
+    "manufacturer": "Siterwell Technology HK Co., Ltd."
+  },
+  "0x0266:0x0006:0x0001": {
+    "description": "carbon monoxide alarm",
+    "label": "GS816",
+    "manufacturer": "Siterwell Technology HK Co., Ltd."
+  },
+  "0x0266:0x0007:0x0001": {
+    "description": "Heat Alarm",
+    "label": "GS412",
+    "manufacturer": "Siterwell Technology HK Co., Ltd."
+  },
+  "0x0267:0x0001:0x0000": {
+    "description": "Switch IO: On/Off Power Switch",
+    "label": "10002034-13X",
+    "manufacturer": "SimonTech S.L.U"
+  },
+  "0x0267:0x0001:0x00da": {
+    "description": "Switch IO: On/Off Power Switch",
+    "label": "10002034-13X",
+    "manufacturer": "SimonTech S.L.U"
+  },
+  "0x0267:0x0001:0x0107": {
+    "description": "Switch IO: On/Off Power Switch",
+    "label": "10002034-13X",
+    "manufacturer": "SimonTech S.L.U"
+  },
+  "0x0267:0x0001:0x0477": {
+    "description": "Switch IO: On/Off Power Switch",
+    "label": "10002034-13X",
+    "manufacturer": "SimonTech S.L.U"
+  },
+  "0x0267:0x0004:0x0000": {
+    "description": "Simon IO: Roller Blind",
+    "label": "10002080-13x",
+    "manufacturer": "SimonTech S.L.U"
+  },
+  "0x0267:0x0004:0x0022": {
+    "description": "Simon IO: Roller Blind",
+    "label": "10002080-13x",
+    "manufacturer": "SimonTech S.L.U"
+  },
+  "0x0267:0x0004:0x0063": {
+    "description": "Simon IO: Roller Blind",
+    "label": "10002080-13x",
+    "manufacturer": "SimonTech S.L.U"
+  },
+  "0x0267:0x0004:0x0091": {
+    "description": "Simon IO: Roller Blind",
+    "label": "10002080-13x",
+    "manufacturer": "SimonTech S.L.U"
+  },
+  "0x0267:0x0004:0x0092": {
+    "description": "Simon IO: Roller Blind",
+    "label": "10002080-13x",
+    "manufacturer": "SimonTech S.L.U"
+  },
+  "0x0267:0x0004:0x0093": {
+    "description": "Simon IO: Roller Blind",
+    "label": "10002080-13x",
+    "manufacturer": "SimonTech S.L.U"
+  },
+  "0x0267:0x0004:0x0094": {
+    "description": "Simon IO: Roller Blind",
+    "label": "10002080-13x",
+    "manufacturer": "SimonTech S.L.U"
+  },
+  "0x0267:0x0004:0x0177": {
+    "description": "Simon IO: Roller Blind",
+    "label": "10002080-13x",
+    "manufacturer": "SimonTech S.L.U"
+  },
+  "0x0267:0x0009:0x0000": {
+    "description": "iO Cover for the Simon 100 schuko plug socket",
+    "label": "10002041-130",
+    "manufacturer": "SimonTech S.L.U"
+  },
+  "0x0267:0x0009:0x0022": {
+    "description": "iO Cover for the Simon 100 Schuko Plug Socket",
+    "label": "10002041-13X",
+    "manufacturer": "SimonTech S.L.U"
+  },
+  "0x0267:0x0011:0x0000": {
+    "description": "Sensor de humo iO",
+    "label": "10002862-039",
+    "manufacturer": "SimonTech S.L.U"
+  },
+  "0x0268:0x0001:0x0001": {
+    "description": "Nexa Bridge",
+    "label": "NEXA BRIDGE V1",
+    "manufacturer": "Nexa Trading AB"
+  },
+  "0x026b:0x0004:0x0004": {
+    "description": "Z-Wave Photoelectric Smoke Alarm",
+    "label": "EIA650RFZ",
+    "manufacturer": "Ei Electronics"
+  },
+  "0x026e:0x4252:0x5a31": {
+    "description": "Basic Remote Control Z-Wave",
+    "label": "BRZ1",
+    "manufacturer": "Springs Window Fashions"
+  },
+  "0x026e:0x4353:0x5a31": {
+    "description": "Cellular Shade Radio Z-Wave",
+    "label": "CSZ1",
+    "manufacturer": "Springs Window Fashions"
+  },
+  "0x026e:0x4d43:0x5a31": {
+    "description": "Multi-Channel Remote Control",
+    "label": "MCZ1",
+    "manufacturer": "Springs Window Fashions"
+  },
+  "0x026e:0x5253:0x5a31": {
+    "description": "Somfy Motorized Shade",
+    "label": "RSZ1",
+    "manufacturer": "Springs Window Fashions"
+  },
+  "0x026e:0x5643:0x5a31": {
+    "description": "Two Button Remote",
+    "label": "VCZ1",
+    "manufacturer": "Springs Window Fashions"
+  },
+  "0x026f:0x0001:0x0001": {
+    "description": "Thermoptek Smoke Alarm/Smoke Detector",
+    "label": "ZST-630",
+    "manufacturer": "Sprue Safety Products Ltd."
+  },
+  "0x026f:0x0002:0x0002": {
+    "description": "Thermistek Heat Alarm/Detector",
+    "label": "ZHT-630",
+    "manufacturer": "Sprue Safety Products Ltd."
+  },
+  "0x0271:0x0001:0x1a73": {
+    "description": "PIR sensor with relay and light",
+    "label": "XLED Home 2",
+    "manufacturer": "STEINEL GmbH"
+  },
+  "0x0271:0x0001:0x1a74": {
+    "description": "Indoor LED-light with motion sensor",
+    "label": "RS LED D2 Z-Wave",
+    "manufacturer": "STEINEL GmbH"
+  },
+  "0x0271:0x0001:0x1a75": {
+    "description": "Sensor-switched outdoor up and downlighting",
+    "label": "L 810 LED iHF",
+    "manufacturer": "STEINEL GmbH"
+  },
+  "0x0271:0x0002:0x19fb": {
+    "description": "Infrared motion detector with orientation light",
+    "label": "MotionSwitch LED",
+    "manufacturer": "STEINEL GmbH"
+  },
+  "0x0271:0x0002:0x1a72": {
+    "description": "PIR sensor with relay",
+    "label": "IS140-2",
+    "manufacturer": "STEINEL GmbH"
+  },
+  "0x0271:0x0002:0x6770": {
+    "description": "PIR sensor with relay",
+    "label": "IS140-2",
+    "manufacturer": "STEINEL GmbH"
+  },
+  "0x0272:0x0001:0x0001": {
+    "description": "Dune HD Solo 4K",
+    "label": "SOLO4K",
+    "manufacturer": "Dune-HD"
+  },
+  "0x0273:0x0003:0x0001": {
+    "description": "Open Sensor",
+    "label": "OSLI-01",
+    "manufacturer": "LG Innotek"
+  },
+  "0x0276:0x0139:0x0001": {
+    "description": "Remotely Controlled Ventilation",
+    "label": "29990",
+    "manufacturer": "Systemair Sverige AB"
+  },
+  "0x0277:0x0001:0x0001": {
+    "description": "Sensor Gateway",
+    "label": "PIX-GW100Z",
+    "manufacturer": "Pixela Corporation"
+  },
+  "0x027a:0x0001:0x0005": {
+    "description": "Outdoor Motion Sensor",
+    "label": "ZSE29",
+    "manufacturer": "Zooz"
+  },
+  "0x027a:0x0003:0x0000": {
+    "description": "Water Sensor",
+    "label": "ZSE30",
+    "manufacturer": "Zooz"
+  },
+  "0x027a:0x0003:0x0003": {
+    "description": "Indoor Siren",
+    "label": "ZSE01",
+    "manufacturer": "Zooz"
+  },
+  "0x027a:0x0003:0x0082": {
+    "description": "Z-Wave Plus Contact Sensor",
+    "label": "ZSE08",
+    "manufacturer": "Zooz"
+  },
+  "0x027a:0x0003:0x0083": {
+    "description": "Motion and Light Mini Sensor",
+    "label": "ZSE09",
+    "manufacturer": "Zooz"
+  },
+  "0x027a:0x0003:0x0085": {
+    "description": "Water Sensor",
+    "label": "ZSE30",
+    "manufacturer": "Zooz"
+  },
+  "0x027a:0x0003:0x0087": {
+    "description": "Mini Plug On / Off Module ZEN07",
+    "label": "ZEN07",
+    "manufacturer": "Zooz"
+  },
+  "0x027a:0x0003:0x0088": {
+    "description": "Smart Chime/Alarm",
+    "label": "ZSE33",
+    "manufacturer": "Zooz"
+  },
+  "0x027a:0x0003:0x0512": {
+    "description": "Valve Control",
+    "label": "ZAC03",
+    "manufacturer": "Zooz"
+  },
+  "0x027a:0x000c:0x0003": {
+    "description": "S2 Multisiren",
+    "label": "ZSE19",
+    "manufacturer": "Zooz"
+  },
+  "0x027a:0x0101:0x000a": {
+    "description": "Smart Plug with 2 USB ports",
+    "label": "ZEN06",
+    "manufacturer": "Zooz"
+  },
+  "0x027a:0x0101:0x000d": {
+    "description": "Power Switch",
+    "label": "ZEN15",
+    "manufacturer": "Zooz"
+  },
+  "0x027a:0x0301:0x0012": {
+    "description": "Motion and Vibration Sensor",
+    "label": "ZSE18",
+    "manufacturer": "Zooz"
+  },
+  "0x027a:0x0401:0x0002": {
+    "description": "S2 USB Stick Controller",
+    "label": "ZST10",
+    "manufacturer": "Zooz"
+  },
+  "0x027a:0x0500:0x0003": {
+    "description": "Motion Sensor",
+    "label": "ZSE02",
+    "manufacturer": "Zooz"
+  },
+  "0x027a:0x0902:0x2000": {
+    "description": "RGBW Dimmer",
+    "label": "ZEN31",
+    "manufacturer": "Zooz"
+  },
+  "0x027a:0x1111:0x1e1c": {
+    "description": "Z-Wave Plus On/Off Toggle Switch V3",
+    "label": "ZEN23",
+    "manufacturer": "Zooz"
+  },
+  "0x027a:0x2021:0x2101": {
+    "description": "4-in-1 Sensor",
+    "label": "ZSE40",
+    "manufacturer": "Zooz"
+  },
+  "0x027a:0x4953:0x3133": {
+    "description": "Portable Smart Motion Sensor",
+    "label": "ZW6302",
+    "manufacturer": "Zooz"
+  },
+  "0x027a:0x7000:0xa001": {
+    "description": "Z-Wave Plus 700 Series ON/OFF Switch",
+    "label": "ZEN71",
+    "manufacturer": "Zooz"
+  },
+  "0x027a:0x7000:0xa002": {
+    "description": "Z-Wave Plus 700 Series Dimmer Switch",
+    "label": "ZEN72",
+    "manufacturer": "Zooz"
+  },
+  "0x027a:0x7000:0xa006": {
+    "description": "Z-Wave Plus 700 Series S2 ON/OFF Switch",
+    "label": "ZEN76",
+    "manufacturer": "Zooz"
+  },
+  "0x027a:0x7000:0xa007": {
+    "description": "Z-Wave Plus 700 Series S2 Dimmer Switch",
+    "label": "ZEN77",
+    "manufacturer": "Zooz"
+  },
+  "0x027a:0x7000:0xa008": {
+    "description": "Scene Controller",
+    "label": "ZEN32",
+    "manufacturer": "Zooz"
+  },
+  "0x027a:0x7000:0xa00a": {
+    "description": "Universal Relay",
+    "label": "ZEN17",
+    "manufacturer": "Zooz"
+  },
+  "0x027a:0x7000:0xf001": {
+    "description": "Z-Wave Plus 700 Series Remote Switch",
+    "label": "ZEN34",
+    "manufacturer": "Zooz"
+  },
+  "0x027a:0xa000:0xa001": {
+    "description": "Z-Wave Plus S2 ON/OFF Switch",
+    "label": "ZEN26",
+    "manufacturer": "Zooz"
+  },
+  "0x027a:0xa000:0xa002": {
+    "description": "Z-Wave Plus S2 Dimmer Light Switch",
+    "label": "ZEN27",
+    "manufacturer": "Zooz"
+  },
+  "0x027a:0xa000:0xa003": {
+    "description": "Double Plug",
+    "label": "ZEN25",
+    "manufacturer": "Zooz"
+  },
+  "0x027a:0xa000:0xa004": {
+    "description": "Z-Wave Plus Power Strip, VER. 2.0",
+    "label": "ZEN20",
+    "manufacturer": "Zooz"
+  },
+  "0x027a:0xa000:0xa008": {
+    "description": "Dimmer & Dry Contact Relay",
+    "label": "ZEN30",
+    "manufacturer": "Zooz"
+  },
+  "0x027a:0xa000:0xa00a": {
+    "description": "Multirelay",
+    "label": "ZEN16",
+    "manufacturer": "Zooz"
+  },
+  "0x027a:0xaa00:0xaa01": {
+    "description": "Z-Wave Plus ON/OFF Switch",
+    "label": "ZEN21",
+    "manufacturer": "Zooz"
+  },
+  "0x027a:0xb111:0x1e1c": {
+    "description": "Z-Wave Plus ON/OFF Switch",
+    "label": "ZEN21",
+    "manufacturer": "Zooz"
+  },
+  "0x027a:0xb111:0x251c": {
+    "description": "Z-Wave Plus On/Off Toggle Switch V3",
+    "label": "ZEN23",
+    "manufacturer": "Zooz"
+  },
+  "0x027a:0xb112:0x1f1c": {
+    "description": "Dimmer Paddle Switch",
+    "label": "ZEN22",
+    "manufacturer": "Zooz"
+  },
+  "0x027a:0xb112:0x261c": {
+    "description": "Z-Wave Plus Toggle Dimmer Light Switch Ver 2.0",
+    "label": "ZEN24",
+    "manufacturer": "Zooz"
+  },
+  "0x027b:0x0001:0x0003": {
+    "description": "White Rabbit Smart Hub",
+    "label": "SH-ZW+CBB+UT",
+    "manufacturer": "White Rabbit"
+  },
+  "0x027e:0x0001:0x0001": {
+    "description": "Nokia Smart Home GPON ONT",
+    "label": "G-240WZ",
+    "manufacturer": "Nokia"
+  },
+  "0x027e:0x0002:0x0001": {
+    "description": "Nokia Smart Home GPON ONT",
+    "label": "G-240WZ",
+    "manufacturer": "Nokia"
+  },
+  "0x0280:0x0001:0x0001": {
+    "description": "smanos Smart Hub",
+    "label": "K2",
+    "manufacturer": "Chuango Security Technology Corporation"
+  },
+  "0x0283:0x0001:0x0001": {
+    "description": "TP-LINK Smart Home Router",
+    "label": "SMART HOME ROUTER",
+    "manufacturer": "TP-Link Technologies Co., Ltd."
+  },
+  "0x0283:0x0001:0x0002": {
+    "description": "TP-LINK Smart Home Router",
+    "label": "SMART HOME ROUTER",
+    "manufacturer": "TP-Link Technologies Co., Ltd."
+  },
+  "0x0285:0x0201:0x0001": {
+    "description": "iCPE",
+    "label": "ICPE",
+    "manufacturer": "CONNECTION TECHNOLOGY SYSTEMS"
+  },
+  "0x0286:0x0186:0x0186": {
+    "description": "Door/Window Sensor",
+    "label": "EH-DS-01",
+    "manufacturer": "Shenzhen Easyhome Technology Co., Ltd."
+  },
+  "0x0286:0x0187:0x0197": {
+    "description": "DoorSensor",
+    "label": "ZWDS01",
+    "manufacturer": "Shenzhen Easyhome Technology Co., Ltd."
+  },
+  "0x0286:0x0188:0x0198": {
+    "description": "DoorSensor",
+    "label": "ZWDS01",
+    "manufacturer": "Shenzhen Easyhome Technology Co., Ltd."
+  },
+  "0x0287:0x0003:0x000d": {
+    "description": "Window Blind Controller",
+    "label": "IB2.0",
+    "manufacturer": "HAB Home Intelligence, LLC"
+  },
+  "0x0287:0x0004:0x0071": {
+    "description": "Window Blind Controller",
+    "label": "iblinds V3",
+    "manufacturer": "HAB Home Intelligence LLC"
+  },
+  "0x028a:0x0001:0x0001": {
+    "description": "Qua station",
+    "label": "KTS31MW",
+    "manufacturer": "Askey Computer Corp."
+  },
+  "0x028c:0x00eb:0xeb20": {
+    "description": "Energy Bridge",
+    "label": "PWLY-274343",
+    "manufacturer": "Powerley"
+  },
+  "0x0293:0x0003:0x0014": {
+    "description": "Four Touch Panel and Power Socket",
+    "label": "HTP-4S1-FB",
+    "manufacturer": "Home controls"
+  },
+  "0x0293:0x0003:0x0018": {
+    "description": "8 way touch light switch",
+    "label": "HTP-8S0-XX",
+    "manufacturer": "Home controls"
+  },
+  "0x0293:0x0003:0x001a": {
+    "description": "Touch Panel Switch",
+    "label": "HG-TS10",
+    "manufacturer": "Home controls"
+  },
+  "0x0293:0x0003:0x0024": {
+    "description": "Z-Wave Switch with 2 on/off light switches and 2 up/down blinds switches",
+    "label": "Lumi LM-S4ZW (C-L)",
+    "manufacturer": "Home controls"
+  },
+  "0x0293:0x0003:0x0113": {
+    "description": "Hogar Pebble",
+    "label": "HC-TB-ZW",
+    "manufacturer": "Home controls"
+  },
+  "0x0293:0x0003:0x4410": {
+    "description": "1 Touch Panel Dimmer",
+    "label": "HTP-1S",
+    "manufacturer": "Home controls"
+  },
+  "0x0293:0x0003:0x4411": {
+    "description": "1 Touch Panel Switch",
+    "label": "HTP-1S0",
+    "manufacturer": "Home controls"
+  },
+  "0x0293:0x0003:0x4412": {
+    "description": "2 Touch Panel Switch",
+    "label": "HTP-2S0",
+    "manufacturer": "Home controls"
+  },
+  "0x0293:0x0003:0x4413": {
+    "description": "3 Touch Panel Switch",
+    "label": "HTP-3S0",
+    "manufacturer": "Home controls"
+  },
+  "0x0293:0x0003:0x4414": {
+    "description": "Z-Wave Switch with 4 on/off light switches",
+    "label": "Lumi LM-SxZW (C-L)",
+    "manufacturer": "Home controls"
+  },
+  "0x0293:0x0003:0x441a": {
+    "description": "10 Touch Panel Switch",
+    "label": "HTP-10S0",
+    "manufacturer": "Home controls"
+  },
+  "0x0295:0x0500:0x0501": {
+    "description": "Home Area Manager",
+    "label": "98-002",
+    "manufacturer": "fifthplay nv"
+  },
+  "0x0296:0x0001:0x0001": {
+    "description": "Home Automation Gateway",
+    "label": "DOC400",
+    "manufacturer": "OBLO LIVING LLC"
+  },
+  "0x0296:0x0001:0x0002": {
+    "description": "Home Automation Gateway",
+    "label": "HA102",
+    "manufacturer": "OBLO LIVING LLC"
+  },
+  "0x0299:0x0001:0x0001": {
+    "description": "COMMAX Smart Lock",
+    "label": "CDL-107U",
+    "manufacturer": "TechniSat Digital GmbH"
+  },
+  "0x0299:0x0001:0x157c": {
+    "description": "DIGIT ISIO STC+",
+    "label": "4757",
+    "manufacturer": "TechniSat Digital GmbH"
+  },
+  "0x0299:0x0001:0x15e0": {
+    "description": "TECHNIMEDIA UHD TV line software",
+    "label": "5600",
+    "manufacturer": "TechniSat Digital GmbH"
+  },
+  "0x0299:0x0001:0x1644": {
+    "description": "DigiPal SMART HOME",
+    "label": "9530",
+    "manufacturer": "TechniSat Digital GmbH"
+  },
+  "0x0299:0x0001:0x1645": {
+    "description": "Zentraleinheit 2",
+    "label": "9531",
+    "manufacturer": "TechniSat Digital GmbH"
+  },
+  "0x0299:0x0001:0x1838": {
+    "description": "SONATA 1",
+    "label": "4790",
+    "manufacturer": "TechniSat Digital GmbH"
+  },
+  "0x0299:0x0001:0x189c": {
+    "description": "TECHNIVISTA TV line software",
+    "label": "6300",
+    "manufacturer": "TechniSat Digital GmbH"
+  },
+  "0x0299:0x0002:0x1a90": {
+    "description": "Flush On/Off switch",
+    "label": "Single-Switch ",
+    "manufacturer": "TechniSat"
+  },
+  "0x0299:0x0003:0x1a91": {
+    "description": "Flush Series Switch",
+    "label": "Double-Switch",
+    "manufacturer": "TechniSat"
+  },
+  "0x0299:0x0004:0x1a92": {
+    "description": "Flush Dimmer Switch",
+    "label": "Dimmer Switch",
+    "manufacturer": "TechniSat"
+  },
+  "0x0299:0x0005:0x1a93": {
+    "description": "Flush Roller Shutter Switch",
+    "label": "Shutter-Switch",
+    "manufacturer": "TechniSat"
+  },
+  "0x0299:0x0200:0x0008": {
+    "description": "Door/Window Sensor",
+    "label": "0000/9518",
+    "manufacturer": "TechniSat Digital GmbH"
+  },
+  "0x029a:0x4882:0x3032": {
+    "description": "Scout Hub 1S",
+    "label": "SCHUB02",
+    "manufacturer": "Scout Alarm"
+  },
+  "0x029f:0x0003:0x0001": {
+    "description": "AMADAS Smart Lock",
+    "label": "ADSL-1001",
+    "manufacturer": "AMADAS Co., Ltd."
+  },
+  "0x0301:0x0048:0x010f": {
+    "description": "Clamp Energy Meter",
+    "label": "Zwave Clamp",
+    "manufacturer": "Seco"
+  },
+  "0x0304:0x0001:0x0001": {
+    "description": "MYHOMEBOX",
+    "label": "1.1.264015",
+    "manufacturer": "MYHOMEBOX B.V."
+  },
+  "0x0307:0x4447:0x3031": {
+    "description": "Z-Wave Plug-In On/Off Appliance Module",
+    "label": "86-100",
+    "manufacturer": "SATCO Products, Inc."
+  },
+  "0x0307:0x4447:0x3033": {
+    "description": "In-Wall On/Off Switch",
+    "label": "86/102",
+    "manufacturer": "SATCO Products, Inc."
+  },
+  "0x030a:0x0103:0x0090": {
+    "description": "Curtain motor",
+    "label": "DT82TV/F-1.2/14",
+    "manufacturer": "Dooya"
+  },
+  "0x030c:0x0001:0xa101": {
+    "description": "Fios Quantum Gateway",
+    "label": "FIOS-G1100-V1",
+    "manufacturer": "Verizon"
+  },
+  "0x030d:0x0101:0x0101": {
+    "description": "Z-Wave Plus Wireless Receiving Controller",
+    "label": "ERC307",
+    "manufacturer": "Hampoo"
+  },
+  "0x030f:0x0001:0x0001": {
+    "description": "Double Switch in a dual relay in-wall module.",
+    "label": "DS100",
+    "manufacturer": "Vemmio"
+  },
+  "0x030f:0x0003:0x0003": {
+    "description": "Motion and Light Mini Sensor",
+    "label": "MT-100",
+    "manufacturer": "Vemmio"
+  },
+  "0x0312:0x0111:0x261c": {
+    "description": "In-wall Smart Dimmer",
+    "label": "NZW31T",
+    "manufacturer": "Inovelli"
+  },
+  "0x0312:0x0221:0x251c": {
+    "description": "Show Home, 2 channel smart plug, ZWave Plus",
+    "label": "ZW37",
+    "manufacturer": "NIE Technology Co., Ltd."
+  },
+  "0x0312:0x1e00:0x1e00": {
+    "description": "In-Wall Switch (On/Off) Scene Enabled",
+    "label": "NZW30S",
+    "manufacturer": "Inovelli"
+  },
+  "0x0312:0x1e01:0x1e01": {
+    "description": "In-Wall Switch (On/Off)",
+    "label": "NZW30",
+    "manufacturer": "Inovelli"
+  },
+  "0x0312:0x1e02:0x1e02": {
+    "description": "In-Wall Switch (On/Off) Scene Enabled",
+    "label": "NZW30T",
+    "manufacturer": "Inovelli"
+  },
+  "0x0312:0x1f00:0x1f00": {
+    "description": "In-Wall Dimming Switch Scene Enabled",
+    "label": "NZW31S",
+    "manufacturer": "Inovelli"
+  },
+  "0x0312:0x1f01:0x1f01": {
+    "description": "In-wall Dimming Switch",
+    "label": "NZW31",
+    "manufacturer": "Inovelli"
+  },
+  "0x0312:0x1f02:0x1f02": {
+    "description": "In-wall Smart Dimmer",
+    "label": "NZW31T",
+    "manufacturer": "Inovelli"
+  },
+  "0x0312:0x2003:0xb31c": {
+    "description": "Smoke Sensor",
+    "label": "ZW1103",
+    "manufacturer": "NIE Technology Co., Ltd."
+  },
+  "0x0312:0x2003:0xb51c": {
+    "description": "Shock Sensor",
+    "label": "ZW1105",
+    "manufacturer": "NIE Technology Co., Ltd."
+  },
+  "0x0312:0x2003:0xc41c": {
+    "description": "Flood leak sensor",
+    "label": "EZW1204",
+    "manufacturer": "NIE Technology Co., Ltd."
+  },
+  "0x0312:0x2400:0x2400": {
+    "description": "On/Off Smart Plug + Signal Repeater (Z-Wave Plus)",
+    "label": "NZW36",
+    "manufacturer": "NIE Technology Co., Ltd."
+  },
+  "0x0312:0x2500:0x2500": {
+    "description": "2-Channel Dual Smart Plug",
+    "label": "NZW37",
+    "manufacturer": "NIE Technology Co., Ltd."
+  },
+  "0x0312:0x2700:0x2700": {
+    "description": "Dimmable Smart Plug",
+    "label": "NZW39",
+    "manufacturer": "NIE Technology Co., Ltd."
+  },
+  "0x0312:0x4000:0x0f1c": {
+    "description": "Siren Box",
+    "label": "ZW15",
+    "manufacturer": "NIE Technology Co., Ltd."
+  },
+  "0x0312:0x6000:0x6000": {
+    "description": "Outdoor Z-Wave Plug-In Module (1-Channel)",
+    "label": "NZW96",
+    "manufacturer": "NIE Technology Co., Ltd."
+  },
+  "0x0312:0x6100:0x6100": {
+    "description": "2-Channel Dual Smart Plug",
+    "label": "NZW37",
+    "manufacturer": "NIE Technology Co., Ltd."
+  },
+  "0x0312:0xa000:0xa007": {
+    "description": "Smart Outlet",
+    "label": "ZW32",
+    "manufacturer": "NIE Technology Co., Ltd."
+  },
+  "0x0312:0xa000:0xaa02": {
+    "description": "S2 In-wall Smart Dimmer switch",
+    "label": "ZW31",
+    "manufacturer": "NIE Technology Co., Ltd."
+  },
+  "0x0312:0xaa00:0xaa01": {
+    "description": "S2 In-wall Smart ON/OFF Switch",
+    "label": "ZW30",
+    "manufacturer": "EVA Logik"
+  },
+  "0x0312:0xb003:0xc11c": {
+    "description": "Door/Window Sensor",
+    "label": "ZW1201",
+    "manufacturer": "NIE Technology Co., Ltd."
+  },
+  "0x0312:0xb112:0x1f1c": {
+    "description": "S2 In-wall Smart Dimmer switch",
+    "label": "ZW31",
+    "manufacturer": "NIE Technology Co., Ltd."
+  },
+  "0x0312:0xb115:0x201c": {
+    "description": "Smart Outlet",
+    "label": "ZW32",
+    "manufacturer": "NIE Technology Co., Ltd."
+  },
+  "0x0312:0xb211:0x241c": {
+    "description": "On/Off Smart Plug + Signal Repeater (Z-Wave Plus)",
+    "label": "NZW36",
+    "manufacturer": "NIE Technology Co., Ltd."
+  },
+  "0x0312:0xb212:0x271c": {
+    "description": "Dimmable Smart Plug",
+    "label": "NZW39",
+    "manufacturer": "NIE Technology Co., Ltd."
+  },
+  "0x0312:0xb221:0x251c": {
+    "description": "2-Channel Dual Smart Plug",
+    "label": "NZW37",
+    "manufacturer": "NIE Technology Co., Ltd."
+  },
+  "0x0312:0xbb00:0xbb01": {
+    "description": "S2 In-wall Smart ON/OFF Switch",
+    "label": "ZW30",
+    "manufacturer": "EVA Logik"
+  },
+  "0x0312:0xc000:0xc002": {
+    "description": "Dimmable Smart Plug",
+    "label": "ZW39",
+    "manufacturer": "NIE Technology Co., Ltd."
+  },
+  "0x0312:0xc001:0xc002": {
+    "description": "Smart Plug with Energy Meter",
+    "label": "ZW681",
+    "manufacturer": "NIE Technology Co., Ltd."
+  },
+  "0x0312:0xe000:0xe004": {
+    "description": "Flood Sensor",
+    "label": "ZW1204",
+    "manufacturer": "NIE Technology Co., Ltd."
+  },
+  "0x0312:0xee00:0xee01": {
+    "description": "Smart On/Off Switch",
+    "label": "MS10Z",
+    "manufacturer": "Minoston"
+  },
+  "0x0312:0xee00:0xee02": {
+    "description": "S2 In-wall Smart Dimmer switch",
+    "label": "ZW31",
+    "manufacturer": "NIE Technology Co., Ltd."
+  },
+  "0x0312:0xee00:0xee03": {
+    "description": "Smart On/Off Toggle Switch",
+    "label": "MS12Z",
+    "manufacturer": "Minoston"
+  },
+  "0x0312:0xee00:0xee04": {
+    "description": "Smart Dimmer Toggle Switch",
+    "label": "MS13Z",
+    "manufacturer": "Ministon"
+  },
+  "0x0312:0xff00:0xff01": {
+    "description": "Smart On/Off Toggle Switch",
+    "label": "MS12Z",
+    "manufacturer": "Minoston"
+  },
+  "0x0312:0xff00:0xff02": {
+    "description": "Smart Dimmer Toggle Switch",
+    "label": "MS13Z",
+    "manufacturer": "Ministon"
+  },
+  "0x0312:0xff00:0xff03": {
+    "description": "Smart On/Off Switch",
+    "label": "MS10Z",
+    "manufacturer": "Minoston"
+  },
+  "0x0312:0xff00:0xff04": {
+    "description": "S2 In-wall Smart Dimmer switch",
+    "label": "ZW31",
+    "manufacturer": "NIE Technology Co., Ltd."
+  },
+  "0x0312:0xff00:0xff05": {
+    "description": "Zwave Plug 2 channel plugin outlet",
+    "label": "MP20Z",
+    "manufacturer": "NIE Technology Co., Ltd."
+  },
+  "0x0312:0xff00:0xff06": {
+    "description": "Smart Plug - 1 channel",
+    "label": "MP21Z",
+    "manufacturer": "Minoston"
+  },
+  "0x0312:0xff00:0xff07": {
+    "description": "Z-Wave Outdoor Smart Plug",
+    "label": "MP22Z",
+    "manufacturer": "Minoston"
+  },
+  "0x0312:0xff00:0xff08": {
+    "description": "Outdoor Smart Plug - 1 channel",
+    "label": "MP23Z",
+    "manufacturer": "Minoston"
+  },
+  "0x0312:0xff00:0xff09": {
+    "description": "Outdoor Smart Plug - 2 channel",
+    "label": "MP24Z",
+    "manufacturer": "Ministon"
+  },
+  "0x0312:0xff00:0xff0c": {
+    "description": "Smart Plug - 1 channel",
+    "label": "MP21Z",
+    "manufacturer": "Minoston"
+  },
+  "0x0312:0xff01:0xff01": {
+    "description": "Smart On/Off Toggle Switch",
+    "label": "MS12Z",
+    "manufacturer": "Minoston"
+  },
+  "0x0312:0xff01:0xff02": {
+    "description": "Smart Dimmer Toggle Switch",
+    "label": "MS13Z",
+    "manufacturer": "Ministon"
+  },
+  "0x0312:0xff01:0xff03": {
+    "description": "Smart On/Off Switch",
+    "label": "MS10Z",
+    "manufacturer": "Minoston"
+  },
+  "0x0312:0xff01:0xff04": {
+    "description": "S2 In-wall Smart Dimmer switch",
+    "label": "ZW31",
+    "manufacturer": "NIE Technology Co., Ltd."
+  },
+  "0x0313:0x0001:0x0001": {
+    "description": "wireless handle",
+    "label": "FG-FR404-ZW-HF",
+    "manufacturer": "Hoppe"
+  },
+  "0x0315:0x0001:0x0001": {
+    "description": "Z-Wave ToolBox",
+    "label": "ZWP-TBX",
+    "manufacturer": "zwaveproducts.com"
+  },
+  "0x0315:0x0202:0x0001": {
+    "description": "Water Leak Detector",
+    "label": "ZL-LD-100",
+    "manufacturer": "zwaveproducts.com"
+  },
+  "0x0315:0x4447:0x3031": {
+    "description": "ZL-PA-100",
+    "label": "ZL-PA-100",
+    "manufacturer": "zwaveproducts.com"
+  },
+  "0x0315:0x4447:0x3033": {
+    "description": "Switch",
+    "label": "WS-100",
+    "manufacturer": "zwaveproducts.com"
+  },
+  "0x0315:0x4447:0x3034": {
+    "description": "In-Wall Dimmer",
+    "label": "WD-100",
+    "manufacturer": "zwaveproducts.com"
+  },
+  "0x0315:0x4744:0x3032": {
+    "description": "Plug-In Dimmer",
+    "label": "ZL-PD-100",
+    "manufacturer": "zwaveproducts.com"
+  },
+  "0x0318:0x0003:0x0001": {
+    "description": "",
+    "label": "ZEM",
+    "manufacturer": "SBCK Corp."
+  },
+  "0x031c:0x0000:0x0000": {
+    "description": "ZWEVEUSB",
+    "label": "ZWEVE-USB-0001",
+    "manufacturer": "Ilevia srl"
+  },
+  "0x031d:0x1101:0x0001": {
+    "description": "Certified Installer Toolkit",
+    "label": "ZWEECIT1",
+    "manufacturer": "Z-Wave Alliance"
+  },
+  "0x031e:0x0001:0x0001": {
+    "description": "Red Series Dimmer",
+    "label": "LZW31-SN",
+    "manufacturer": "Inovelli"
+  },
+  "0x031e:0x0002:0x0001": {
+    "description": "Red Series On/Off switch",
+    "label": "LZW30-SN",
+    "manufacturer": "Inovelli"
+  },
+  "0x031e:0x0003:0x0001": {
+    "description": "Black Series Dimmer",
+    "label": "LZW31",
+    "manufacturer": "Inovelli"
+  },
+  "0x031e:0x0004:0x0001": {
+    "description": "Base model On-Off switch",
+    "label": "LZW30",
+    "manufacturer": "Inovelli"
+  },
+  "0x031e:0x0005:0x0001": {
+    "description": "Multi-Color Bulb",
+    "label": "LZW42",
+    "manufacturer": "Inovelli"
+  },
+  "0x031e:0x0006:0x0001": {
+    "description": "Tunable White Smart Bulb",
+    "label": "LZW41",
+    "manufacturer": "Inovelli"
+  },
+  "0x031e:0x0007:0x0001": {
+    "description": "Smart Bulb",
+    "label": "LZW40",
+    "manufacturer": "Inovelli"
+  },
+  "0x031e:0x000a:0x0001": {
+    "description": "Light Strip",
+    "label": "LZW45",
+    "manufacturer": "Inovelli"
+  },
+  "0x031e:0x000d:0x0001": {
+    "description": "4-in-1 Sensor",
+    "label": "LZW60",
+    "manufacturer": "Inovelli"
+  },
+  "0x031e:0x000e:0x0001": {
+    "description": "Red Series Fan + Light Switch",
+    "label": "LZW36",
+    "manufacturer": "Inovelli"
+  },
+  "0x0320:0x0001:0x0001": {
+    "description": "Magnetic Contact",
+    "label": "HO-09ZW",
+    "manufacturer": "China Security & Fire IOT Sensing CO., Ltd."
+  },
+  "0x0320:0x0002:0x0001": {
+    "description": "Wireless Passive Infrared Detector",
+    "label": "LH-990ZW",
+    "manufacturer": "China Security & Fire IOT Sensing CO., Ltd."
+  },
+  "0x0329:0x0004:0x0008": {
+    "description": "In-Wall On/Off Switch Module",
+    "label": "LIZY0005",
+    "manufacturer": "COMAP"
+  },
+  "0x032b:0x2001:0x0106": {
+    "description": "Door Sensor",
+    "label": "ZD2102-5",
+    "manufacturer": "Anchor Tech"
+  },
+  "0x032c:0x3003:0x0006": {
+    "description": "Door/Window Detect Sensor",
+    "label": "SK-3003-06",
+    "manufacturer": "Shenzhen Saykey Technology Co., Ltd."
+  },
+  "0x032c:0x3003:0x0007": {
+    "description": "PIR Detect Sensor",
+    "label": "SK-3003-07",
+    "manufacturer": "Shenzhen Saykey Technology Co., Ltd."
+  },
+  "0x032c:0x3007:0x0005": {
+    "description": "Curtain Motor Control external module",
+    "label": "SK-3007-05",
+    "manufacturer": "Shenzhen Saykey Technology Co., Ltd."
+  },
+  "0x032c:0x5005:0x0002": {
+    "description": "Keyfob Remote Control",
+    "label": "SK-5005-02",
+    "manufacturer": "Shenzhen Saykey Technology Co., Ltd."
+  },
+  "0x032d:0x3002:0x0006": {
+    "description": "",
+    "label": "BSL01",
+    "manufacturer": "Benetek"
+  },
+  "0x032e:0x0004:0x0042": {
+    "description": "DSI-101 binary switch",
+    "label": "DSI-101 binary switch",
+    "manufacturer": "DEFARO"
+  },
+  "0x032e:0x0021:0x0013": {
+    "description": "Double relay Switch 2x1.7kW",
+    "label": "DAS-102",
+    "manufacturer": "DEFARO"
+  },
+  "0x032e:0x0060:0x0031": {
+    "description": "Dimmer with sensors support",
+    "label": "DAD-101",
+    "manufacturer": "DEFARO"
+  },
+  "0x0330:0x0003:0xa10d": {
+    "description": "Wall Controller",
+    "label": "SR-ZV9001T4-DIM",
+    "manufacturer": "ShenZhen Sunricher Technology, Ltd."
+  },
+  "0x0330:0x0003:0xa305": {
+    "description": "4 group single color wall mounted remote",
+    "label": "ZV9001K8-DIM",
+    "manufacturer": "Sunricher"
+  },
+  "0x0330:0x0003:0xa306": {
+    "description": "2 group single color wall mounted remote",
+    "label": "ZV9001K4-DIM-G2",
+    "manufacturer": "Sunricher"
+  },
+  "0x0330:0x0003:0xa310": {
+    "description": "Z-Wave Dim Remote Control",
+    "label": "ZV9001K4-DIM",
+    "manufacturer": "Sunricher"
+  },
+  "0x0330:0x0200:0xd002": {
+    "description": "Z-wave CCT LED controller",
+    "label": "ZV9102FA-CCT",
+    "manufacturer": "Sunricher"
+  },
+  "0x0330:0x0200:0xd005": {
+    "description": "In-Wall Dimmer Module",
+    "label": "ZV-9101",
+    "manufacturer": "Sunricher"
+  },
+  "0x0330:0x0200:0xd010": {
+    "description": "Knob Smart Dimmer",
+    "label": "ZV2400TAC-SL-A",
+    "manufacturer": "Sunricher"
+  },
+  "0x0330:0x0201:0xd002": {
+    "description": "RGBW LED Controller",
+    "label": "ZV9101",
+    "manufacturer": "Sunricher"
+  },
+  "0x0330:0x0201:0xd004": {
+    "description": "NAMRON Smart Plug",
+    "label": "VEGGPLUG",
+    "manufacturer": "Sunricher"
+  },
+  "0x0330:0x0300:0xa103": {
+    "description": "4 group CCT touch panel secondary controller",
+    "label": "ZV9002T4-CCT",
+    "manufacturer": "Sunricher"
+  },
+  "0x0330:0x0300:0xa107": {
+    "description": "Touch Panel RGBW Z Wave Wall Controller",
+    "label": "ZV9001T4-RGBW",
+    "manufacturer": "Sunricher"
+  },
+  "0x0330:0x0300:0xa305": {
+    "description": "Wall Mounted Switch",
+    "label": "Heatit Z-Push Button 8",
+    "manufacturer": "Sunricher"
+  },
+  "0x0330:0x0300:0xa30f": {
+    "description": "Z-Wave Dim Remote Control",
+    "label": "SR-ZV9001K2-DIM",
+    "manufacturer": "ShenZhen Sunricher Technology, Ltd."
+  },
+  "0x0330:0x0300:0xb301": {
+    "description": "5 Channel Dimmer Remote Control",
+    "label": "ZV9001K12-DIM-Z5",
+    "manufacturer": "Sunricher"
+  },
+  "0x0330:0x0300:0xb302": {
+    "description": "4 Channel Dimmer Remote Control",
+    "label": "ZV9001K12-DIM-Z4",
+    "manufacturer": "Sunricher"
+  },
+  "0x0330:0x0301:0xa101": {
+    "description": "Wall Controller",
+    "label": "SR-ZV9002T3-CCT",
+    "manufacturer": "ShenZhen Sunricher Technology, Ltd."
+  },
+  "0x0330:0x0301:0xa105": {
+    "description": "RGBW 3-Zone Wall Mount Touch Panel",
+    "label": "ZV9001T3-RGBW",
+    "manufacturer": "Sunricher"
+  },
+  "0x0330:0x0301:0xa106": {
+    "description": "RGBW 3 Scene Wall Controller",
+    "label": "ZV9003T3-RGBW",
+    "manufacturer": "Sunricher"
+  },
+  "0x0330:0x0301:0xa109": {
+    "description": "Wall Controller",
+    "label": "SR-ZV9001T3-DIM",
+    "manufacturer": "ShenZhen Sunricher Technology, Ltd."
+  },
+  "0x0330:0x0301:0xb301": {
+    "description": "5 Channel Dimmer Remote Control",
+    "label": "ZV9001K12-DIM-Z5",
+    "manufacturer": "Sunricher"
+  },
+  "0x0330:0x0301:0xb302": {
+    "description": "4 Channel Dimmer Remote Control",
+    "label": "ZV9001K12-DIM-Z4",
+    "manufacturer": "Sunricher"
+  },
+  "0x0330:0x0302:0xb301": {
+    "description": "5 Channel Dimmer Remote Control",
+    "label": "ZV9001K12-DIM-Z5",
+    "manufacturer": "Sunricher"
+  },
+  "0x0330:0x0302:0xb302": {
+    "description": "4 Channel Dimmer Remote Control",
+    "label": "ZV9001K12-DIM-Z4",
+    "manufacturer": "Sunricher"
+  },
+  "0x0330:0x031a:0xa10d": {
+    "description": "Wall Controller",
+    "label": "SR-ZV9001T4-DIM",
+    "manufacturer": "ShenZhen Sunricher Technology, Ltd."
+  },
+  "0x0331:0x0001:0x1001": {
+    "description": "Gateway",
+    "label": "WK-0001",
+    "manufacturer": "Winka Electronic Co., Ltd."
+  },
+  "0x0333:0x0001:0x0001": {
+    "description": "Home IoT",
+    "label": "TH-GW10",
+    "manufacturer": "Toshiba Visual Solution"
+  },
+  "0x0337:0x0001:0x0002": {
+    "description": "BL 900HW",
+    "label": "H03HG4",
+    "manufacturer": "KDDI"
+  },
+  "0x0337:0x0001:0x0003": {
+    "description": "BL 902HW",
+    "label": "H03HV2",
+    "manufacturer": "KDDI"
+  },
+  "0x0337:0x0001:0x0004": {
+    "description": "Wi-Fi Gateway",
+    "label": "HSI01(KTS32)",
+    "manufacturer": "KDDI"
+  },
+  "0x0337:0x0001:0x0005": {
+    "description": "BL1000HW",
+    "label": "H03HG8",
+    "manufacturer": "KDDI"
+  },
+  "0x033f:0x0000:0x0594": {
+    "description": "August Smart Lock Pro 3rd Gen",
+    "label": "ASL-03",
+    "manufacturer": "August Home"
+  },
+  "0x033f:0x0000:0xdf29": {
+    "description": "August Smart Lock Pro 3rd Gen",
+    "label": "ASL-03",
+    "manufacturer": "August Home"
+  },
+  "0x033f:0x0001:0x0001": {
+    "description": "August Smart Lock Pro 3rd Gen",
+    "label": "ASL-03",
+    "manufacturer": "August Home"
+  },
+  "0x0344:0x0003:0x0001": {
+    "description": "Wall Heating Thermostat",
+    "label": "HE-ZW-THERM-FL2",
+    "manufacturer": "HELTUN"
+  },
+  "0x0345:0x0001:0x0001": {
+    "description": "Swidget module with USB port",
+    "label": "ZW000RW",
+    "manufacturer": "Swidget Corp"
+  },
+  "0x0346:0x0001:0x0101": {
+    "description": "Ring Alarm Base Station",
+    "label": "RING BASE STATION",
+    "manufacturer": "Ring"
+  },
+  "0x0346:0x0101:0x0201": {
+    "description": "Alarm Keypad (1st generation)",
+    "label": "4AK1S7-0EN0 / 4AK1E9-0EU0",
+    "manufacturer": "Ring"
+  },
+  "0x0346:0x0101:0x0202": {
+    "description": "Alarm Keypad (1st generation)",
+    "label": "4AK1S7-0EN0 / 4AK1E9-0EU0",
+    "manufacturer": "Ring"
+  },
+  "0x0346:0x0201:0x0201": {
+    "description": "Contact Sensor",
+    "label": "4SD1S7-0EN0 / 4SDAE9-0EU0",
+    "manufacturer": "Ring"
+  },
+  "0x0346:0x0201:0x0202": {
+    "description": "Contact Sensor",
+    "label": "4SD1S7-0EN0 / 4SDAE9-0EU0",
+    "manufacturer": "Ring"
+  },
+  "0x0346:0x0301:0x0201": {
+    "description": "Motion Sensor",
+    "label": "4SP1S7-0EN0 / 4SPAE9-0EU0",
+    "manufacturer": "Ring"
+  },
+  "0x0346:0x0301:0x0202": {
+    "description": "Motion Sensor",
+    "label": "4SP1S7-0EN0 / 4SPAE9-0EU0",
+    "manufacturer": "Ring"
+  },
+  "0x0346:0x0401:0x0101": {
+    "description": "Range Extender (1st generation)",
+    "label": "4AR1S7-0EN0 / 4AR1E9-0EU0",
+    "manufacturer": "Ring"
+  },
+  "0x0346:0x0401:0x0102": {
+    "description": "Range Extender (1st generation)",
+    "label": "4AR1S7-0EN0 / 4AR1E9-0EU0",
+    "manufacturer": "Ring"
+  },
+  "0x0348:0x0001:0x0001": {
+    "description": "Central Home Unit",
+    "label": "CHU00001-W",
+    "manufacturer": "KUNDO xT GmbH"
+  },
+  "0x0349:0x0013:0x3700": {
+    "description": "homee Z-Wave Cube",
+    "label": "HOMEE\u20130002",
+    "manufacturer": "Codeatelier GmbH"
+  },
+  "0x0349:0x0013:0x3900": {
+    "description": "homee Z-Wave Cube Green",
+    "label": "ESTMK-Z-WAV",
+    "manufacturer": "Codeatelier GmbH"
+  },
+  "0x034b:0x0001:0x0001": {
+    "description": "iRemocon Wi-Fi",
+    "label": "IRM-03WL",
+    "manufacturer": "Glamo Inc."
+  },
+  "0x034c:0x0003:0x0001": {
+    "description": "PIR Sensor",
+    "label": "KAS-Z10",
+    "manufacturer": "KOCOM"
+  },
+  "0x034c:0x0003:0x0002": {
+    "description": "Door / Window Sensor",
+    "label": "KMS-Z10",
+    "manufacturer": "KOCOM"
+  },
+  "0x034e:0x0001:0x0005": {
+    "description": "Radio RGBW",
+    "label": "MTRGB-100-WL",
+    "manufacturer": "TEM AG"
+  },
+  "0x034e:0x0001:0x0100": {
+    "description": "Radio Server",
+    "label": "MTSER-100-WL",
+    "manufacturer": "TEM AG"
+  },
+  "0x034e:0x0001:0x0101": {
+    "description": "Radio Base Modul",
+    "label": "MTBAS-100-WL",
+    "manufacturer": "TEM AG"
+  },
+  "0x034f:0x0003:0x0001": {
+    "description": "electronic deadbolt lock",
+    "label": "PL2S0S10-ZW",
+    "manufacturer": "TONG LUNG METAL INDUSTRY CO., Ltd."
+  },
+  "0x0353:0x0001:0x0001": {
+    "description": "Connect+ Security Panel with Z-Wave Controller",
+    "label": "RE6100",
+    "manufacturer": "Alula"
+  },
+  "0x0357:0x0057:0x0002": {
+    "description": "",
+    "label": "UPowerSwitch",
+    "manufacturer": "Shenzhen 3nod Acousticlink Co., Ltd."
+  },
+  "0x0357:0x0058:0x0002": {
+    "description": "",
+    "label": "UPowerSwitch",
+    "manufacturer": "Shenzhen 3nod Acousticlink Co., Ltd."
+  },
+  "0x0357:0x0059:0x0002": {
+    "description": "",
+    "label": "UPowerSwitch",
+    "manufacturer": "Shenzhen 3nod Acousticlink Co., Ltd."
+  },
+  "0x0358:0x0001:0x0001": {
+    "description": "LodeStar",
+    "label": "LSHAC-Z5B3K4-100",
+    "manufacturer": "Star Automation"
+  },
+  "0x0361:0x0003:0x0008": {
+    "description": "TOASTCAM",
+    "label": "V3 / NE350",
+    "manufacturer": "NHN Entertainment"
+  },
+  "0x0363:0x0005:0x0005": {
+    "description": "Z-Wave Smart Motor Actuator",
+    "label": "IOTX-Z-ACTMOTOR001",
+    "manufacturer": "Nanjing IoTx Intelligent Technology Co., Ltd."
+  },
+  "0x0364:0x0001:0x0001": {
+    "description": "",
+    "label": "M5065",
+    "manufacturer": "Axis Communications Ab"
+  },
+  "0x0364:0x0002:0x0001": {
+    "description": "PIR Motion Sensor",
+    "label": "T8341",
+    "manufacturer": "Axis Communications Ab"
+  },
+  "0x0364:0x0003:0x0001": {
+    "description": "Door/Window Sensor",
+    "label": "T8342",
+    "manufacturer": "Axis Communications Ab"
+  },
+  "0x0364:0x0004:0x0001": {
+    "description": "Power On/Off Plug",
+    "label": "T8344",
+    "manufacturer": "Axis Communications Ab"
+  },
+  "0x0364:0x0005:0x0001": {
+    "description": "Alert Button",
+    "label": "T8343",
+    "manufacturer": "Axis Communications Ab"
+  },
+  "0x0366:0x0001:0x0001": {
+    "description": "Philia Door Lock",
+    "label": "PDS-100",
+    "manufacturer": "PHILIA TECHNOLOGY Co., Ltd."
+  },
+  "0x0367:0x0001:0x0001": {
+    "description": "Vesta Shield",
+    "label": "SVHSZWB1",
+    "manufacturer": "Vesta"
+  },
+  "0x0369:0x0001:0x0001": {
+    "description": "Controller",
+    "label": "CW7",
+    "manufacturer": "2KLIC"
+  },
+  "0x0369:0x0100:0x0101": {
+    "description": "Connectair Module",
+    "label": "7440-MC-FS",
+    "manufacturer": "2KLIC"
+  },
+  "0x036f:0x0001:0x0001": {
+    "description": "Eugenio",
+    "label": "SENTINEL 2.0",
+    "manufacturer": "Evolvere SpA"
+  },
+  "0x0370:0x2001:0x0106": {
+    "description": "Door Sensor",
+    "label": "ZD2102-5",
+    "manufacturer": "Raylios"
+  },
+  "0x0370:0x2001:0x01a1": {
+    "description": "Door Sensor",
+    "label": "ZD2112JP-5",
+    "manufacturer": "Raylios"
+  },
+  "0x0370:0x2022:0x2201": {
+    "description": "Door Sensor",
+    "label": "ZD2105US-5",
+    "manufacturer": "Raylios"
+  },
+  "0x0371:0x0001:0x0014": {
+    "description": "AutoPilot",
+    "label": "ZWA020",
+    "manufacturer": "Aeotec Ltd."
+  },
+  "0x0371:0x0002:0x0003": {
+    "description": "NanoMote Quad",
+    "label": "Aeotec NanoMote Quad",
+    "manufacturer": "Aeotec Ltd."
+  },
+  "0x0371:0x0002:0x0005": {
+    "description": "Motion, light, and temperature sensor",
+    "label": "ZWA005",
+    "manufacturer": "Aeotec Ltd."
+  },
+  "0x0371:0x0002:0x0007": {
+    "description": "Door/Window Sensor 7",
+    "label": "ZWA008",
+    "manufacturer": "Aeotec Ltd."
+  },
+  "0x0371:0x0002:0x0009": {
+    "description": "aerQ Temperature and Humidity Sensor",
+    "label": "ZWA009",
+    "manufacturer": "Aeotec Ltd."
+  },
+  "0x0371:0x0002:0x0015": {
+    "description": "Thermostat - HVAC",
+    "label": "Radiator Thermostat",
+    "manufacturer": "Aeotec Ltd."
+  },
+  "0x0371:0x0002:0x00bb": {
+    "description": "Recessed Door Sensor 7",
+    "label": "ZW187",
+    "manufacturer": "Aeotec Ltd."
+  },
+  "0x0371:0x0003:0x0001": {
+    "description": "Bulb 6 Multi-White",
+    "label": "ZWA001",
+    "manufacturer": "Aeotec Ltd."
+  },
+  "0x0371:0x0003:0x0002": {
+    "description": "Bulb 6 Multi-Color",
+    "label": "ZWA002",
+    "manufacturer": "Aeotec Ltd."
+  },
+  "0x0371:0x0003:0x00a2": {
+    "description": "Indoor Siren 6 and Doorbell 6",
+    "label": "ZW164",
+    "manufacturer": "Aeotec Ltd."
+  },
+  "0x0371:0x0003:0x00a4": {
+    "description": "Indoor Siren 6 and Doorbell 6",
+    "label": "ZW164",
+    "manufacturer": "Aeotec Ltd."
+  },
+  "0x0371:0x0003:0x00af": {
+    "description": "Smart Switch 7",
+    "label": "ZW175",
+    "manufacturer": "Aeotec Ltd."
+  },
+  "0x0371:0x0004:0x00bd": {
+    "description": "Range Extender 7",
+    "label": "ZW189-C15",
+    "manufacturer": "Aeotec Ltd."
+  },
+  "0x0371:0x0102:0x0003": {
+    "description": "NanoMote Quad",
+    "label": "Aeotec NanoMote Quad",
+    "manufacturer": "Aeotec Ltd."
+  },
+  "0x0371:0x0102:0x0005": {
+    "description": "Motion, light, and temperature sensor",
+    "label": "ZWA005",
+    "manufacturer": "Aeotec Ltd."
+  },
+  "0x0371:0x0102:0x0007": {
+    "description": "Door/Window Sensor 7",
+    "label": "ZWA008",
+    "manufacturer": "Aeotec Ltd."
+  },
+  "0x0371:0x0102:0x0009": {
+    "description": "aerQ Temperature and Humidity Sensor",
+    "label": "ZWA009",
+    "manufacturer": "Aeotec Ltd."
+  },
+  "0x0371:0x0102:0x00bb": {
+    "description": "Recessed Door Sensor 7",
+    "label": "ZW187",
+    "manufacturer": "Aeotec Ltd."
+  },
+  "0x0371:0x0103:0x0001": {
+    "description": "Bulb 6 Multi-White",
+    "label": "ZWA001",
+    "manufacturer": "Aeotec Ltd."
+  },
+  "0x0371:0x0103:0x0002": {
+    "description": "Bulb 6 Multi-Color",
+    "label": "ZWA002",
+    "manufacturer": "Aeotec Ltd."
+  },
+  "0x0371:0x0103:0x00a2": {
+    "description": "Indoor Siren 6 and Doorbell 6",
+    "label": "ZW164",
+    "manufacturer": "Aeotec Ltd."
+  },
+  "0x0371:0x0103:0x00a4": {
+    "description": "Indoor Siren 6 and Doorbell 6",
+    "label": "ZW164",
+    "manufacturer": "Aeotec Ltd."
+  },
+  "0x0371:0x0104:0x00bd": {
+    "description": "Range Extender 7",
+    "label": "ZW189-C15",
+    "manufacturer": "Aeotec Ltd."
+  },
+  "0x0371:0x0202:0x0005": {
+    "description": "Motion, light, and temperature sensor",
+    "label": "ZWA005",
+    "manufacturer": "Aeotec Ltd."
+  },
+  "0x0371:0x0202:0x0007": {
+    "description": "Door/Window Sensor 7",
+    "label": "ZWA008",
+    "manufacturer": "Aeotec Ltd."
+  },
+  "0x0371:0x0203:0x00a4": {
+    "description": "Indoor Siren 6 and Doorbell 6",
+    "label": "ZW164",
+    "manufacturer": "Aeotec Ltd."
+  },
+  "0x0373:0x0003:0x0001": {
+    "description": "Z wave module for ID Lock 150 and 101",
+    "label": "ID-150",
+    "manufacturer": "ID Lock AS"
+  },
+  "0x0374:0x0001:0x0001": {
+    "description": "Z-Wave Gateway Controller and hub",
+    "label": "HCS-W1001",
+    "manufacturer": "Hyundai Telecom"
+  },
+  "0x0374:0x0001:0x0081": {
+    "description": "DIGITAL DOOR LOCK",
+    "label": "HDL-5200SK",
+    "manufacturer": "Hyundai Telecom"
+  },
+  "0x0374:0x0001:0x0082": {
+    "description": "DIGITAL DOOR LOCK",
+    "label": "HDL-7300SK",
+    "manufacturer": "Hyundai Telecom"
+  },
+  "0x0374:0x0001:0x0083": {
+    "description": "DIGITAL DOOR LOCK",
+    "label": "HDL-7390SK",
+    "manufacturer": "Hyundai Telecom"
+  },
+  "0x0374:0x0002:0x0001": {
+    "description": "Z-Wave Gateway Controller and hub",
+    "label": "HCS-W1001",
+    "manufacturer": "Hyundai Telecom"
+  },
+  "0x0374:0x0003:0x0001": {
+    "description": "Z-Wave Gateway Controller and hub",
+    "label": "HAS-R2071M",
+    "manufacturer": "Hyundai Telecom"
+  },
+  "0x0374:0x0004:0x0001": {
+    "description": "Z-Wave Gateway Controller and hub",
+    "label": "HCS-W1001",
+    "manufacturer": "Hyundai Telecom"
+  },
+  "0x0374:0x0005:0x0001": {
+    "description": "Z-Wave Gateway Controller and hub",
+    "label": "HCS-W1001",
+    "manufacturer": "Hyundai Telecom"
+  },
+  "0x0377:0x0001:0x0001": {
+    "description": "Smart Home Gateway",
+    "label": "WSR 1706 V 1.0",
+    "manufacturer": "HORNBACH Baumarkt AG"
+  },
+  "0x037b:0x0002:0x0001": {
+    "description": "keyWe Smart Lock",
+    "label": "GKW-2000",
+    "manufacturer": "Guardtec Inc."
+  },
+  "0x037b:0x0003:0x0001": {
+    "description": "KeyWe Rim Lock",
+    "label": "GKW-1000Z",
+    "manufacturer": "Guardtec Inc."
+  },
+  "0x037b:0x0006:0x0001": {
+    "description": "Staybinder Smart Door Lock",
+    "label": "GKBC-3100Z",
+    "manufacturer": "Guardtec Inc."
+  },
+  "0x037b:0x0010:0x0001": {
+    "description": "KeyWe Smart Rim Lock",
+    "label": "GKDL-5100Z",
+    "manufacturer": "Guardtec Inc."
+  },
+  "0x037b:0x0011:0x0001": {
+    "description": "KeyWe Smart Rim Lock",
+    "label": "GKDL-5100Z",
+    "manufacturer": "Guardtec Inc."
+  },
+  "0x037b:0x0012:0x0001": {
+    "description": "KeyWe Smart Rim Lock",
+    "label": "GKDL-5000Z",
+    "manufacturer": "Guardtec Inc."
+  },
+  "0x037c:0x0002:0x0036": {
+    "description": "Single Function Magnetic Sensor",
+    "label": "PSM08-3E",
+    "manufacturer": "Eco Life Engineering Co., Ltd."
+  },
+  "0x037c:0x0005:0x0063": {
+    "description": "In Wall Dimmer",
+    "label": "PAD07-3E",
+    "manufacturer": "Eco Life Engineering Co., Ltd."
+  },
+  "0x038e:0x0001:0x0001": {
+    "description": "NortheastGas Association Wireless Methane Gas Detector",
+    "label": "TFW-01",
+    "manufacturer": "NYSEARCH"
+  },
+  "0x0392:0x0001:0x0001": {
+    "description": "Animus Heart",
+    "label": "AHG1",
+    "manufacturer": "Animus Home AB"
+  },
+  "0x0398:0x4753:0x07ea": {
+    "description": "GigaSPIRE MAX",
+    "label": "GS2026E",
+    "manufacturer": "Calix"
+  },
+  "0x0399:0x0001:0x0001": {
+    "description": "Hubitat Elevation",
+    "label": "C-7",
+    "manufacturer": "Hubitat"
+  },
+  "0x039b:0x0001:0x0013": {
+    "description": "TIM_BOX",
+    "label": "UZW4010TIM2",
+    "manufacturer": "Reply S.p.A."
+  },
+  "0x0400:0x0001:0x0001": {
+    "description": "iota",
+    "label": "IOT",
+    "manufacturer": "Abode"
+  },
+  "0x0402:0x0001:0x0001": {
+    "description": "AI Home Gateway",
+    "label": "NCP-HG100",
+    "manufacturer": "Sony Mobile Communications Inc."
+  },
+  "0x0402:0x0002:0x0001": {
+    "description": "ONU Integrated Service Router",
+    "label": "NSD-G1000T",
+    "manufacturer": "Sony Mobile Communications Inc."
+  },
+  "0x0403:0x0001:0x0001": {
+    "description": "ABUS Z-Wave Gateway",
+    "label": "SHGW10000",
+    "manufacturer": "ABUS Security-Center GmbH & Co. KG"
+  },
+  "0x0403:0x0002:0x0000": {
+    "description": "Magnetic Contact",
+    "label": "SHMK10000",
+    "manufacturer": "ABUS Security-Center GmbH & Co. KG"
+  },
+  "0x0403:0x0002:0x0001": {
+    "description": "PIR Multisensor",
+    "label": "SHBW10000",
+    "manufacturer": "ABUS Security-Center GmbH & Co. KG"
+  },
+  "0x0403:0x0002:0x0002": {
+    "description": "Flood Sensor",
+    "label": "SHWM10000",
+    "manufacturer": "ABUS Security-Center GmbH & Co. KG"
+  },
+  "0x0403:0x0002:0x0003": {
+    "description": "Smart Smoke Sensor",
+    "label": "SHRM10000",
+    "manufacturer": "ABUS Security-Center GmbH Co. KG"
+  },
+  "0x0403:0x0003:0x0000": {
+    "description": "High-volume siren (95 dB) and LED strobe light",
+    "label": "SHSG10000",
+    "manufacturer": "ABUS Security-Center GmbH & Co. KG"
+  },
+  "0x0403:0x0003:0x0002": {
+    "description": "ABUS Security Center Bulb",
+    "label": "SHLM10010",
+    "manufacturer": "ABUS Security-Center GmbH & Co. KG"
+  },
+  "0x0403:0x0003:0x0003": {
+    "description": "Smart Wireless Plug",
+    "label": "SHHA10000",
+    "manufacturer": "ABUS Security-Center GmbH & Co. KG"
+  },
+  "0x0403:0x0004:0x0005": {
+    "description": "Z-Wave Button",
+    "label": "SHBE10000",
+    "manufacturer": "ABUS Security-Center GmbH & Co. KG"
+  },
+  "0x0407:0x0001:0x0001": {
+    "description": "Smart Station",
+    "label": "LS090WH",
+    "manufacturer": "Hangzhou Lifesmart Technology Co., Ltd."
+  },
+  "0x0407:0x0001:0x0002": {
+    "description": "Smart Station",
+    "label": "LS090WH",
+    "manufacturer": "Hangzhou Lifesmart Technology Co., Ltd."
+  },
+  "0x0408:0x0001:0x0073": {
+    "description": "Gerber Prime Switch",
+    "label": "GPS-2000",
+    "manufacturer": "Gerber Technology"
+  },
+  "0x0409:0x0005:0x0003": {
+    "description": "Z-Wave Door Lock",
+    "label": "CFA3010",
+    "manufacturer": "ABUS"
+  },
+  "0x040b:0x0001:0x0001": {
+    "description": "Home Automation and Control Unit",
+    "label": "PGZNG1-2ADNAS",
+    "manufacturer": "Arlo Technologies, Inc."
+  },
+  "0x040d:0x0001:0x0003": {
+    "description": "Megapixel Z-Wave IP Camera",
+    "label": "ZW100",
+    "manufacturer": "Delaney Hardware"
+  },
+  "0x040d:0x0003:0x0001": {
+    "description": "Smartlock",
+    "label": "ZW300",
+    "manufacturer": "Delaney Hardware"
+  },
+  "0x040f:0x0001:0x0001": {
+    "description": "Z-Wave Smart IR Repeater",
+    "label": "RS-ZWIREX1",
+    "manufacturer": "RATOC Systems Inc."
+  },
+  "0x0412:0x0001:0x0001": {
+    "description": "Z-WAVE_BLE_Converter",
+    "label": "LTA-ML",
+    "manufacturer": "Nihon Lock Service Co., Ltd."
+  },
+  "0x0415:0x0001:0x0001": {
+    "description": "Dwelo Hub 3",
+    "label": "DGW101",
+    "manufacturer": "Dwelo Inc."
+  },
+  "0x0415:0x0001:0x0002": {
+    "description": "Dwelo Hub 3",
+    "label": "DGW101",
+    "manufacturer": "Dwelo Inc."
+  },
+  "0x0415:0x0001:0x0003": {
+    "description": "Dwelo Hub 3",
+    "label": "DGW101",
+    "manufacturer": "Dwelo Inc."
+  },
+  "0x0418:0x0003:0x0001": {
+    "description": "Smart Ashley+Z",
+    "label": "YDL110DZ",
+    "manufacturer": "UNION COMMUNITY Co., Ltd."
+  },
+  "0x041b:0x0001:0x0001": {
+    "description": "All-In-One Touchscreen Security",
+    "label": "PROA7PL",
+    "manufacturer": "Resideo"
+  },
+  "0x041b:0x0001:0x0004": {
+    "description": "Chandelier",
+    "label": "TUXEDOW",
+    "manufacturer": "Resideo"
+  },
+  "0x041b:0x4944:0x3038": {
+    "description": "In-Wall Smart Dimmer",
+    "label": "39458 / ZW3010",
+    "manufacturer": "Resideo"
+  },
+  "0x041b:0x4952:0x3036": {
+    "description": "In-Wall Smart Switch",
+    "label": "39455 / ZW4008",
+    "manufacturer": "Resideo"
+  },
+  "0x041b:0x4952:0x3133": {
+    "description": "In-Wall Tamper Resistant Outlet",
+    "label": "39456 / ZW1002",
+    "manufacturer": "Resideo"
+  },
+  "0x041b:0x4f50:0x3035": {
+    "description": "Plug-in Outdoor Smart Switch",
+    "label": "39453 / ZW4203",
+    "manufacturer": "Resideo"
+  },
+  "0x041b:0x5044:0x3033": {
+    "description": "Plug-in Dimmer (Dual Plug Simultaneous Control)",
+    "label": "39446 / ZW3107",
+    "manufacturer": "Resideo"
+  },
+  "0x041b:0x5052:0x3033": {
+    "description": "Plug-in Switch (Dual Plug Simultaneous Control)",
+    "label": "39449 / ZW4106",
+    "manufacturer": "Resideo"
+  },
+  "0x041c:0x8001:0x1000": {
+    "description": "Motion Sensor",
+    "label": "51111",
+    "manufacturer": "Kjell & Co Elektronik"
+  },
+  "0x041c:0x8002:0x1000": {
+    "description": "Smart Smoke Alarm",
+    "label": "51114",
+    "manufacturer": "Kjell & Co Elektronik"
+  },
+  "0x041c:0x8006:0x1000": {
+    "description": "Smart Metering Plug",
+    "label": "51110",
+    "manufacturer": "Kjell & Co Elektronik"
+  },
+  "0x041c:0x8007:0x1000": {
+    "description": "Smart Humidity And Temperature Sensor",
+    "label": "51112",
+    "manufacturer": "Kjell & Co Elektronik"
+  },
+  "0x041e:0x0001:0x0001": {
+    "description": "SmartHome IoT Hub",
+    "label": "EIH-100E",
+    "manufacturer": "Enplug"
+  },
+  "0x0426:0x0003:0x0001": {
+    "description": "4 CHANNEL RELAY",
+    "label": "JR-4C01",
+    "manufacturer": "JR Automation Technology"
+  },
+  "0x0427:0x0001:0x0001": {
+    "description": "",
+    "label": "KAIHEISENSOR 03",
+    "manufacturer": "ATSUMI Electric Co., Ltd."
+  },
+  "0x0427:0x0001:0x0002": {
+    "description": "4 in 1 Multi Sensor",
+    "label": "ZNS10",
+    "manufacturer": "ATSUMI Electric Co., Ltd."
+  },
+  "0x042a:0x2022:0x2202": {
+    "description": "Recessed Door/ Window Sensor",
+    "label": "ZD2105US-5",
+    "manufacturer": "Great Connection System Pte. Ltd."
+  },
+  "0x042c:0x0001:0x0001": {
+    "description": "Walmart WiFi Bridge",
+    "label": "WMBR",
+    "manufacturer": "Walmart, Inc."
+  },
+  "0x042f:0x0001:0x0001": {
+    "description": "IOTAS Hub",
+    "label": "CONNECT2",
+    "manufacturer": "IOTAS"
+  },
+  "0x0431:0x0202:0x0001": {
+    "description": "ECO-DIM Z-Wave Led dimmer",
+    "label": "ECO-DIM",
+    "manufacturer": "EcoDim"
+  },
+  "0x0431:0x0202:0x0002": {
+    "description": "ECO-DIM Z-Wave Led dimmer",
+    "label": "ECO-DIM",
+    "manufacturer": "EcoDim"
+  },
+  "0x0432:0x0001:0x0001": {
+    "description": "ONE X5100",
+    "label": "S30851-S2563-R101",
+    "manufacturer": "Gigaset"
+  },
+  "0x0433:0x0003:0x0005": {
+    "description": "Q-Light Puck",
+    "label": "Z-Wave Puck",
+    "manufacturer": "Q-light"
+  },
+  "0x0433:0x0003:0x000d": {
+    "description": "Q-Light Zerodim",
+    "label": "Zerodim",
+    "manufacturer": "Q-light"
+  },
+  "0x0433:0x0003:0x000e": {
+    "description": "Q-Light Zerodim 2-Pol",
+    "label": "ZERODIM 2-Pol",
+    "manufacturer": "Q-light"
+  },
+  "0x0436:0x0004:0x5001": {
+    "description": "1 Gang Touch Panel Switch",
+    "label": "LM-S1ZW",
+    "manufacturer": "Lumi"
+  },
+  "0x0438:0x0300:0xa306": {
+    "description": "",
+    "label": "2 KANALER BRYTER",
+    "manufacturer": "Namron AS"
+  },
+  "0x0438:0x0300:0xa30f": {
+    "description": "",
+    "label": "1 KANAL BRYTER",
+    "manufacturer": "Namron AS"
+  },
+  "0x0447:0x0111:0x1101": {
+    "description": "Z-Wave Plug-in",
+    "label": "SQR62101WHZ",
+    "manufacturer": "Schneider Electric"
+  },
+  "0x0447:0x0111:0x1102": {
+    "description": "Z-Wave Switch Single Pole",
+    "label": "SQR14101**Z",
+    "manufacturer": "Schneider Electric"
+  },
+  "0x0447:0x0111:0x1105": {
+    "description": "Z-Wave Receptacle",
+    "label": "SQR44101**Z",
+    "manufacturer": "Schneider Electric"
+  },
+  "0x0447:0x0111:0x1201": {
+    "description": "Z-Wave Dimmer",
+    "label": "SQR22101**Z",
+    "manufacturer": "Schneider Electric"
+  },
+  "0x044b:0x0004:0x0002": {
+    "description": "Z-Wave Touchable Smart Valve",
+    "label": "WP-02SF",
+    "manufacturer": "Dongguan Will Power"
+  },
+  "0x5254:0x0000:0x531e": {
+    "description": "Z-Wave enabled universal remote control",
+    "label": "Z-URC500",
+    "manufacturer": "Remotec"
+  },
+  "0x5254:0x0000:0x531f": {
+    "description": "Z-Wave enabled universal remote control",
+    "label": "Z-URC500",
+    "manufacturer": "Remotec"
+  },
+  "0x5254:0x0000:0x5320": {
+    "description": "Z-Wave enabled universal remote control",
+    "label": "Z-URC500",
+    "manufacturer": "Remotec"
+  },
+  "0x5254:0x0000:0x8380": {
+    "description": "Remote Control",
+    "label": "ZRC-100",
+    "manufacturer": "Remotec"
+  },
+  "0x5254:0x0000:0x8510": {
+    "description": "Scene master 8 button remote",
+    "label": "BW8510",
+    "manufacturer": "Remotec"
+  },
+  "0x5254:0x0001:0x8332": {
+    "description": "Z-Wave enabled universal remote control",
+    "label": "Z-URC500",
+    "manufacturer": "Remotec"
+  },
+  "0x5254:0x0001:0x8380": {
+    "description": "Remote Control",
+    "label": "ZRC-100",
+    "manufacturer": "Remotec"
+  },
+  "0x5254:0x0001:0x8510": {
+    "description": "Scene master 8 button remote",
+    "label": "BW8510",
+    "manufacturer": "Remotec"
+  },
+  "0x5254:0x0002:0x0004": {
+    "description": "",
+    "label": "Z-URC 300",
+    "manufacturer": "Remotec"
+  },
+  "0x5254:0x0002:0x8380": {
+    "description": "Remote Control",
+    "label": "ZRC-100",
+    "manufacturer": "Remotec"
+  },
+  "0x5254:0x0002:0x8510": {
+    "description": "Scene master 8 button remote",
+    "label": "BW8510",
+    "manufacturer": "Remotec"
+  },
+  "0x5254:0x000b:0x8510": {
+    "description": "ZRC-90CN",
+    "label": "BW8510CN",
+    "manufacturer": "Remotec"
+  },
+  "0x5254:0x0100:0x8371": {
+    "description": "Remotec ZXT-310US",
+    "label": "BW8371",
+    "manufacturer": "Remotec"
+  },
+  "0x5254:0x0100:0x8377": {
+    "description": "AC IR Remote",
+    "label": "ZXT-120",
+    "manufacturer": "Remotec"
+  },
+  "0x5254:0x0100:0x8490": {
+    "description": "AC Master",
+    "label": "ZXT-600",
+    "manufacturer": "Remotec"
+  },
+  "0x5254:0x0101:0x8370": {
+    "description": "Remotec ZXT-310US",
+    "label": "BW8371",
+    "manufacturer": "Remotec"
+  },
+  "0x5254:0x0101:0x8377": {
+    "description": "AC IR Remote",
+    "label": "ZXT-120",
+    "manufacturer": "Remotec"
+  },
+  "0x5254:0x0101:0x8490": {
+    "description": "AC Master",
+    "label": "ZXT-600",
+    "manufacturer": "Remotec"
+  },
+  "0x5254:0x0102:0x8371": {
+    "description": "AV IR Extender",
+    "label": "ZXT-310",
+    "manufacturer": "Remotec"
+  },
+  "0x5254:0x0102:0x8377": {
+    "description": "AC IR Remote",
+    "label": "ZXT-120",
+    "manufacturer": "Remotec"
+  },
+  "0x5254:0x0102:0x8490": {
+    "description": "AC Master",
+    "label": "ZXT-600",
+    "manufacturer": "Remotec"
+  },
+  "0x5254:0x0107:0x8377": {
+    "description": "Remotec",
+    "label": "BW8377IL",
+    "manufacturer": "Remotec"
+  },
+  "0x5254:0x0200:0x8030": {
+    "description": "ZTS-100US Thermostat",
+    "label": "BW8030",
+    "manufacturer": "Remotec"
+  },
+  "0x5254:0x0200:0x8031": {
+    "description": "ZTS-110 Z Wave Thermostat",
+    "label": "ZTS-110",
+    "manufacturer": "Remotec"
+  },
+  "0x5254:0x0200:0x8170": {
+    "description": "Thermostat",
+    "label": "ZTS-500",
+    "manufacturer": "Remotec"
+  },
+  "0x5254:0x0202:0x8031": {
+    "description": "ZTS-110 Z Wave Thermostat",
+    "label": "ZTS-110",
+    "manufacturer": "Remotec"
+  },
+  "0x5254:0x0202:0x8170": {
+    "description": "Thermostat",
+    "label": "ZTS-500",
+    "manufacturer": "Remotec"
+  },
+  "0x5254:0x1000:0x8140": {
+    "description": "US Z-Wave Repeater",
+    "label": "ZRP-100US / BW8140",
+    "manufacturer": "Remotec"
+  },
+  "0x5254:0x1000:0x8141": {
+    "description": "Z-Wave Repeater",
+    "label": "ZRP-110",
+    "manufacturer": "Remotec"
+  },
+  "0x5254:0x1009:0x8180": {
+    "description": "Z-Wave Slim Repeater",
+    "label": "ZRP-200JP",
+    "manufacturer": "Remotec"
+  },
+  "0x5254:0x8000:0x0002": {
+    "description": "Fixture Switch Module",
+    "label": "ZFM-80 / ZDW-80 / ZRW-80",
+    "manufacturer": "Remotec"
+  },
+  "0x5254:0x8001:0x0000": {
+    "description": "Remotec Switch Module",
+    "label": "ZRM-80S",
+    "manufacturer": "Remotec"
+  },
+  "0x5254:0x8001:0x8020": {
+    "description": "Wall plug switch",
+    "label": "BW8020S",
+    "manufacturer": "Remotec"
+  },
+  "0x5254:0x8200:0x8130": {
+    "description": "Dimming Switch Module (Dual Mode)",
+    "label": "ZDS-210NA",
+    "manufacturer": "Remotec"
+  },
+  "0x5254:0x8201:0x0200": {
+    "description": "Remotec Dimming Module",
+    "label": "ZDM-80S",
+    "manufacturer": "Remotec"
+  },
+  "0x5254:0x8201:0x8021": {
+    "description": "Wall plug dimmer switch",
+    "label": "ZDM-80",
+    "manufacturer": "Remotec"
+  },
+  "0x5254:0x8201:0x8120": {
+    "description": "Dual Mode Switch-Dimmer",
+    "label": "BW8120",
+    "manufacturer": "Remotec"
+  },
+  "updated_at": "2021-03-18T20:06:56.767014"
+}


### PR DESCRIPTION
Add script to facilitate updating file before a PR is opened
Remove initial download requirement when first retrieving info about a Z-Wave device attached to a Vivint system
Change device emit to include reference to device as well as message in event
Remove error handling around listener callbacks and push it back to consumers