### PR TITLE
Add battery level to thermostat

### DIFF
--- a/vivintpy/devices/thermostat.py
+++ b/vivintpy/devices/thermostat.py
@@ -22,6 +22,23 @@ class Thermostat(VivintDevice):
             [self._manufacturer, self._model] = ["Google", "Nest"]
 
     @property
+    def battery_level(self) -> int:
+        """Sensor's battery level."""
+        battery_level = self.data.get(Attribute.BATTERY_LEVEL)
+        return (
+            battery_level
+            if battery_level not in (None, "")
+            else 0
+            if self.low_battery
+            else 100
+        )
+
+    @property
+    def low_battery(self) -> bool:
+        """Return true if battery's level is low."""
+        return self.data.get(Attribute.LOW_BATTERY, False)
+
+    @property
     def cool_set_point(self) -> float:
         """Return the cool set point of the thermostat."""
         return self.data.get(Attribute.COOL_SET_POINT)

--- a/vivintpy/devices/thermostat.py
+++ b/vivintpy/devices/thermostat.py
@@ -1,4 +1,6 @@
 """Module that implements the Thermostat class."""
+from __future__ import annotations
+
 import logging
 
 from ..const import ThermostatAttribute as Attribute
@@ -22,21 +24,19 @@ class Thermostat(VivintDevice):
             [self._manufacturer, self._model] = ["Google", "Nest"]
 
     @property
-    def battery_level(self) -> int:
+    def battery_level(self) -> int | None:
         """Sensor's battery level."""
         battery_level = self.data.get(Attribute.BATTERY_LEVEL)
         return (
-            battery_level
-            if battery_level not in (None, "")
-            else 0
-            if self.low_battery
-            else 100
+            int(battery_level)
+            if battery_level is not None
+            else None
         )
 
     @property
-    def low_battery(self) -> bool:
+    def low_battery(self) -> bool | None:
         """Return true if battery's level is low."""
-        return self.data.get(Attribute.LOW_BATTERY, False)
+        return self.data.get(Attribute.LOW_BATTERY)
 
     @property
     def cool_set_point(self) -> float:


### PR DESCRIPTION
My thermostat is battery powered.

Sorry for the bad image, but this is how it shows on my panel:
![20220727_193013](https://user-images.githubusercontent.com/7625337/181925749-9a70af2c-5176-4942-925f-f0c28fa8ce9c.jpg)

<details>
  <summary>This library provided the following <code class="notranslate">data</code> <b>(Click to expand)</b></summary>
  
```py
{
  "_id": 264,
  "aact": 0,
  "aaht": 0,
  "act": "ct200_thermostat_device",
  "asvn": 27,
  "avn": 11,
  "bl": 40,
  "busy_status": 0,
  "caca": [
    {
      "ca": [
        10,
        11,
        12,
        13,
        14,
        18,
        19,
        21,
        22
      ],
      "ca_vals": {
        "11": 1.66667,
        "12": 35,
        "13": 1,
        "14": 2
      },
      "t": 4
    },
    {
      "ca": [
        31
      ],
      "t": 8
    }
  ],
  "cbr": true,
  "csp": 21.666666666666668,
  "er": 1,
  "fea": {
    "hvac_away_setback": true,
    "hvac_schedules": true
  },
  "fm": 0,
  "fms": [
    0,
    1,
    99,
    100,
    102,
    101,
    103,
    104,
    105,
    107,
    106
  ],
  "from_sync": 1,
  "fs": 0,
  "fwv": [
    [
      0,
      34
    ],
    [
      114,
      16
    ]
  ],
  "hat": 0,
  "hcs": 1,
  "hct": 0,
  "hdte": 2,
  "hhf": 0,
  "hhps": 0,
  "hhs": 1,
  "hht": 0,
  "hidden": false,
  "hm": 3,
  "hmdt": 39,
  "hos": 1,
  "hsp": 18.88888888888889,
  "hwv": 0,
  "ia": true,
  "isl": false,
  "lb": false,
  "manid": 152,
  "maxt": 32.2,
  "mbs": true,
  "mint": 4.44,
  "mspdc": 1,
  "mspdf": 2,
  "n": "Thermostat",
  "nid": 5,
  "ol": true,
  "om": 2,
  "oms": [
    0,
    1,
    2,
    3
  ],
  "os": 0,
  "panid": 2380390233379278,
  "pheat": {
    "ariv": false,
    "away": false,
    "awk": false,
    "slp": false,
    "vcan": false
  },
  "plctx": {
    "mid": "62e541dd6f33a499676bfc58",
    "ts": "2022-07-30T14:36:13.467000"
  },
  "pnlctx": {
    "ts": "2022-07-30T14:36:13.467000"
  },
  "pnlrep": {
    "scct": {
      "away": 25.55556,
      "home": 23.33333,
      "sleep": 24.44444,
      "vacation": 27.77778
    },
    "scht": {
      "away": 17.77778,
      "home": 20,
      "sleep": 18.88889,
      "vacation": 15.55556
    }
  },
  "prid": 34,
  "proph": {
    "csp": [
      {
        "sync": false,
        "ts": "2022-07-30T09:27:56.000000",
        "val": 21.666666666666668
      }
    ],
    "hsp": [
      {
        "sync": false,
        "ts": "2022-07-18T14:00:01.000000",
        "val": 18.88888888888889
      }
    ]
  },
  "prtid": 51201,
  "rcm": 2,
  "scct": {
    "away": 25.55556,
    "home": 23.33333,
    "sleep": 24.44444,
    "vacation": 27.77778
  },
  "scht": {
    "away": 17.77778,
    "home": 20,
    "sleep": 18.88889,
    "vacation": 15.55556
  },
  "sctm": {
    "sctmcc": 2,
    "sctmhc": 2,
    "sctmi": 2,
    "sctmsf": 2000
  },
  "skt": {
    "ariv": "just_do",
    "away": "ask_then_do",
    "awk": "just_do",
    "home": "ask_then_do",
    "slp": "do_then_tell",
    "vcan": "do_then_tell"
  },
  "sku": "VS-CT200",
  "sws": 0,
  "t": "thermostat_device",
  "tcal": 0,
  "trns": true,
  "ts": "2022-07-30T14:36:13.467000",
  "val": 21.666666666666668,
  "wdcs": [
    [
      6,
      0,
      21.666666666666668
    ],
    [
      8,
      0,
      23.333333333333332
    ],
    [
      18,
      0,
      21.666666666666668
    ],
    [
      22,
      0,
      21.11111111111111
    ]
  ],
  "wdhs": [
    [
      6,
      0,
      20.555555555555557
    ],
    [
      8,
      0,
      18.88888888888889
    ],
    [
      18,
      0,
      20
    ],
    [
      22,
      0,
      18.88888888888889
    ]
  ],
  "wecs": [
    [
      6,
      0,
      21.666666666666668
    ],
    [
      8,
      0,
      23.333333333333332
    ],
    [
      18,
      0,
      21.666666666666668
    ],
    [
      22,
      0,
      21.11111111111111
    ]
  ],
  "wehs": [
    [
      6,
      0,
      20
    ],
    [
      8,
      0,
      21.11111111111111
    ],
    [
      18,
      0,
      20
    ],
    [
      22,
      0,
      18.88888888888889
    ]
  ],
  "zpd": "6.51.05"
}
```
</details>

Notably, `bl` (battery level) and `lb` (low battery) were present in `data`, but they weren't being exposed as properties of the Thermostat class. This PR fixes that, hopefully in a way that correctly handles cases where `bl` and `lb` aren't present. I stole the logic from [`wireless_sensor.py`](https://github.com/natekspencer/vivintpy/blob/main/vivintpy/devices/wireless_sensor.py).