### PR TITLE
Exit delay support

### DIFF
--- a/vivintpy/__init__.py
+++ b/vivintpy/__init__.py
@@ -1,3 +1,3 @@
 """Provide a package for vivintpy."""
 
-__version__ = "0.0.0"
+__version__ = "2026.0.3b1.post1.dev0+7a62c7f"

--- a/vivintpy/devices/alarm_panel.py
+++ b/vivintpy/devices/alarm_panel.py
@@ -41,6 +41,7 @@ class AlarmPanel(VivintDevice):
         self.__parse_data(data=data, init=True)
 
         # store a reference to the physical panel device
+        self._exit_delay_task: asyncio.Task | None = None
         self.__panel_credentials: dict = {}
         self.__panel = first_or_none(
             self.devices,
@@ -134,15 +135,36 @@ class AlarmPanel(VivintDevice):
 
     async def disarm(self) -> None:
         """Disarm the alarm."""
+        if self._exit_delay_task is not None:
+            self._exit_delay_task.cancel()
+            self._exit_delay_task = None
         await self.set_armed_state(ArmedState.DISARMED)
 
-    async def arm_stay(self) -> None:
-        """Set the alarm to armed stay."""
-        await self.set_armed_state(ArmedState.ARMED_STAY)
+    async def _delayed_arm(self, state: ArmedState, delay: int) -> None:
+        """Arm after a delay, allowing cancellation."""
+        await asyncio.sleep(delay)
+        self._exit_delay_task = None
+        await self.set_armed_state(state)
 
-    async def arm_away(self) -> None:
+    async def arm_stay(self, exit_delay: int = 0) -> None:
+        """Set the alarm to armed stay."""
+        if exit_delay > 0:
+            self.update_data({Attribute.STATE: ArmedState.ARMING_STAY_IN_EXIT_DELAY})
+            self._exit_delay_task = asyncio.create_task(
+                self._delayed_arm(ArmedState.ARMED_STAY, exit_delay)
+            )
+        else:
+            await self.set_armed_state(ArmedState.ARMED_STAY)
+
+    async def arm_away(self, exit_delay: int = 0) -> None:
         """Set the alarm to armed away."""
-        await self.set_armed_state(ArmedState.ARMED_AWAY)
+        if exit_delay > 0:
+            self.update_data({Attribute.STATE: ArmedState.ARMING_AWAY_IN_EXIT_DELAY})
+            self._exit_delay_task = asyncio.create_task(
+                self._delayed_arm(ArmedState.ARMED_AWAY, exit_delay)
+            )
+        else:
+            await self.set_armed_state(ArmedState.ARMED_AWAY)
 
     async def get_panel_credentials(self, refresh: bool = False) -> dict:
         """Get the panel credentials."""

--- a/vivintpy/devices/alarm_panel.py
+++ b/vivintpy/devices/alarm_panel.py
@@ -152,7 +152,7 @@ class AlarmPanel(VivintDevice):
         """Set the alarm to armed stay."""
         if exit_delay > 0 and self.is_disarmed:
             # Setting in API immediately sets state to armed, so we set the
-            # state locally instead...
+            # state locally instead
             # await self.set_armed_state(ArmedState.ARMING_STAY_IN_EXIT_DELAY)
             self.update_data({Attribute.STATE: ArmedState.ARMING_STAY_IN_EXIT_DELAY})
             self._exit_delay_task = asyncio.create_task(
@@ -165,7 +165,7 @@ class AlarmPanel(VivintDevice):
         """Set the alarm to armed away."""
         if exit_delay > 0 and self.is_disarmed:
             # Setting in API immediately sets state to armed, so we set the
-            # state locally instead...
+            # state locally instead
             # await self.set_armed_state(ArmedState.ARMING_AWAY_IN_EXIT_DELAY)
             self.update_data({Attribute.STATE: ArmedState.ARMING_AWAY_IN_EXIT_DELAY})
             self._exit_delay_task = asyncio.create_task(

--- a/vivintpy/devices/alarm_panel.py
+++ b/vivintpy/devices/alarm_panel.py
@@ -152,7 +152,7 @@ class AlarmPanel(VivintDevice):
         """Set the alarm to armed stay."""
         if exit_delay > 0:
             # Setting in API immediately sets state to armed, so we set the 
-            # state locally instead.
+            # state locally instead...
             # await self.set_armed_state(ArmedState.ARMING_STAY_IN_EXIT_DELAY)
             self.update_data({Attribute.STATE: ArmedState.ARMING_STAY_IN_EXIT_DELAY})
             self._exit_delay_task = asyncio.create_task(
@@ -165,7 +165,7 @@ class AlarmPanel(VivintDevice):
         """Set the alarm to armed away."""
         if exit_delay > 0:
             # Setting in API immediately sets state to armed, so we set the 
-            # state locally instead.
+            # state locally instead...
             # await self.set_armed_state(ArmedState.ARMING_AWAY_IN_EXIT_DELAY)
             self.update_data({Attribute.STATE: ArmedState.ARMING_AWAY_IN_EXIT_DELAY})
             self._exit_delay_task = asyncio.create_task(

--- a/vivintpy/devices/alarm_panel.py
+++ b/vivintpy/devices/alarm_panel.py
@@ -159,9 +159,10 @@ class AlarmPanel(VivintDevice):
             # state locally instead
             # await self.set_armed_state(ArmedState.ARMING_STAY_IN_EXIT_DELAY)
             self.update_data({Attribute.STATE: ArmedState.ARMING_STAY_IN_EXIT_DELAY})
-            self._exit_delay_task = asyncio.create_task(
-                self._delayed_arm(ArmedState.ARMED_STAY, exit_delay)
-            )
+            if self._exit_delay_task is None:
+                self._exit_delay_task = asyncio.create_task(
+                    self._delayed_arm(ArmedState.ARMED_STAY, exit_delay)
+                )
         else:
             await self.set_armed_state(ArmedState.ARMED_STAY)
 
@@ -172,9 +173,10 @@ class AlarmPanel(VivintDevice):
             # state locally instead
             # await self.set_armed_state(ArmedState.ARMING_AWAY_IN_EXIT_DELAY)
             self.update_data({Attribute.STATE: ArmedState.ARMING_AWAY_IN_EXIT_DELAY})
-            self._exit_delay_task = asyncio.create_task(
-                self._delayed_arm(ArmedState.ARMED_AWAY, exit_delay)
-            )
+            if self._exit_delay_task is None:
+                self._exit_delay_task = asyncio.create_task(
+                    self._delayed_arm(ArmedState.ARMED_AWAY, exit_delay)
+                )
         else:
             await self.set_armed_state(ArmedState.ARMED_AWAY)
 

--- a/vivintpy/devices/alarm_panel.py
+++ b/vivintpy/devices/alarm_panel.py
@@ -148,9 +148,22 @@ class AlarmPanel(VivintDevice):
 
     async def _delayed_arm(self, state: ArmedState, delay: int) -> None:
         """Arm after a delay, allowing cancellation."""
-        await asyncio.sleep(delay)
-        self._exit_delay_task = None
-        await self.set_armed_state(state)
+        task = asyncio.current_task()
+        try:
+            await asyncio.sleep(delay)
+            if self._exit_delay_task is not task:
+                return
+            expected_state = (
+                ArmedState.ARMING_STAY_IN_EXIT_DELAY
+                if state == ArmedState.ARMED_STAY
+                else ArmedState.ARMING_AWAY_IN_EXIT_DELAY
+            )
+            if self.state != expected_state:
+                return
+            await self.set_armed_state(state)
+        finally:
+            if self._exit_delay_task is task:
+                self._exit_delay_task = None
 
     async def arm_stay(self, exit_delay: int = 0) -> None:
         """Set the alarm to armed stay."""

--- a/vivintpy/devices/alarm_panel.py
+++ b/vivintpy/devices/alarm_panel.py
@@ -138,8 +138,6 @@ class AlarmPanel(VivintDevice):
         if self._exit_delay_task is not None:
             self._exit_delay_task.cancel()
             self._exit_delay_task = None
-            self.update_data({Attribute.STATE: ArmedState.DISARMED})
-            return
         await self.set_armed_state(ArmedState.DISARMED)
 
     async def _delayed_arm(self, state: ArmedState, delay: int) -> None:
@@ -151,7 +149,7 @@ class AlarmPanel(VivintDevice):
     async def arm_stay(self, exit_delay: int = 0) -> None:
         """Set the alarm to armed stay."""
         if exit_delay > 0:
-            self.update_data({Attribute.STATE: ArmedState.ARMING_STAY_IN_EXIT_DELAY})
+            await self.set_armed_state(ArmedState.ARMING_STAY_IN_EXIT_DELAY)
             self._exit_delay_task = asyncio.create_task(
                 self._delayed_arm(ArmedState.ARMED_STAY, exit_delay)
             )
@@ -161,7 +159,7 @@ class AlarmPanel(VivintDevice):
     async def arm_away(self, exit_delay: int = 0) -> None:
         """Set the alarm to armed away."""
         if exit_delay > 0:
-            self.update_data({Attribute.STATE: ArmedState.ARMING_AWAY_IN_EXIT_DELAY})
+            await self.set_armed_state(ArmedState.ARMING_AWAY_IN_EXIT_DELAY)
             self._exit_delay_task = asyncio.create_task(
                 self._delayed_arm(ArmedState.ARMED_AWAY, exit_delay)
             )

--- a/vivintpy/devices/alarm_panel.py
+++ b/vivintpy/devices/alarm_panel.py
@@ -138,6 +138,8 @@ class AlarmPanel(VivintDevice):
         if self._exit_delay_task is not None:
             self._exit_delay_task.cancel()
             self._exit_delay_task = None
+            self.update_data({Attribute.STATE: ArmedState.DISARMED})
+            return
         await self.set_armed_state(ArmedState.DISARMED)
 
     async def _delayed_arm(self, state: ArmedState, delay: int) -> None:
@@ -149,7 +151,10 @@ class AlarmPanel(VivintDevice):
     async def arm_stay(self, exit_delay: int = 0) -> None:
         """Set the alarm to armed stay."""
         if exit_delay > 0:
-            await self.set_armed_state(ArmedState.ARMING_STAY_IN_EXIT_DELAY)
+            # Setting in API immediately sets state to armed, so we set the 
+            # state locally instead.
+            # await self.set_armed_state(ArmedState.ARMING_STAY_IN_EXIT_DELAY)
+            self.update_data({Attribute.STATE: ArmedState.ARMING_STAY_IN_EXIT_DELAY})
             self._exit_delay_task = asyncio.create_task(
                 self._delayed_arm(ArmedState.ARMED_STAY, exit_delay)
             )
@@ -159,7 +164,10 @@ class AlarmPanel(VivintDevice):
     async def arm_away(self, exit_delay: int = 0) -> None:
         """Set the alarm to armed away."""
         if exit_delay > 0:
-            await self.set_armed_state(ArmedState.ARMING_AWAY_IN_EXIT_DELAY)
+            # Setting in API immediately sets state to armed, so we set the 
+            # state locally instead.
+            # await self.set_armed_state(ArmedState.ARMING_AWAY_IN_EXIT_DELAY)
+            self.update_data({Attribute.STATE: ArmedState.ARMING_AWAY_IN_EXIT_DELAY})
             self._exit_delay_task = asyncio.create_task(
                 self._delayed_arm(ArmedState.ARMED_AWAY, exit_delay)
             )

--- a/vivintpy/devices/alarm_panel.py
+++ b/vivintpy/devices/alarm_panel.py
@@ -40,8 +40,9 @@ class AlarmPanel(VivintDevice):
 
         self.__parse_data(data=data, init=True)
 
-        # store a reference to the physical panel device
         self._exit_delay_task: asyncio.Task | None = None
+
+        # store a reference to the physical panel device
         self.__panel_credentials: dict = {}
         self.__panel = first_or_none(
             self.devices,

--- a/vivintpy/devices/alarm_panel.py
+++ b/vivintpy/devices/alarm_panel.py
@@ -138,8 +138,12 @@ class AlarmPanel(VivintDevice):
         if self._exit_delay_task is not None:
             self._exit_delay_task.cancel()
             self._exit_delay_task = None
-            self.update_data({Attribute.STATE: ArmedState.DISARMED})
-            return
+            if self.state in (
+                ArmedState.ARMING_STAY_IN_EXIT_DELAY,
+                ArmedState.ARMING_AWAY_IN_EXIT_DELAY,
+            ):
+                self.update_data({Attribute.STATE: ArmedState.DISARMED})
+                return
         await self.set_armed_state(ArmedState.DISARMED)
 
     async def _delayed_arm(self, state: ArmedState, delay: int) -> None:

--- a/vivintpy/devices/alarm_panel.py
+++ b/vivintpy/devices/alarm_panel.py
@@ -150,8 +150,8 @@ class AlarmPanel(VivintDevice):
 
     async def arm_stay(self, exit_delay: int = 0) -> None:
         """Set the alarm to armed stay."""
-        if exit_delay > 0:
-            # Setting in API immediately sets state to armed, so we set the 
+        if exit_delay > 0 and self.is_disarmed:
+            # Setting in API immediately sets state to armed, so we set the
             # state locally instead...
             # await self.set_armed_state(ArmedState.ARMING_STAY_IN_EXIT_DELAY)
             self.update_data({Attribute.STATE: ArmedState.ARMING_STAY_IN_EXIT_DELAY})
@@ -163,8 +163,8 @@ class AlarmPanel(VivintDevice):
 
     async def arm_away(self, exit_delay: int = 0) -> None:
         """Set the alarm to armed away."""
-        if exit_delay > 0:
-            # Setting in API immediately sets state to armed, so we set the 
+        if exit_delay > 0 and self.is_disarmed:
+            # Setting in API immediately sets state to armed, so we set the
             # state locally instead...
             # await self.set_armed_state(ArmedState.ARMING_AWAY_IN_EXIT_DELAY)
             self.update_data({Attribute.STATE: ArmedState.ARMING_AWAY_IN_EXIT_DELAY})

--- a/vivintpy/devices/alarm_panel.py
+++ b/vivintpy/devices/alarm_panel.py
@@ -138,6 +138,8 @@ class AlarmPanel(VivintDevice):
         if self._exit_delay_task is not None:
             self._exit_delay_task.cancel()
             self._exit_delay_task = None
+            self.update_data({Attribute.STATE: ArmedState.DISARMED})
+            return
         await self.set_armed_state(ArmedState.DISARMED)
 
     async def _delayed_arm(self, state: ArmedState, delay: int) -> None:

--- a/vivintpy/zjs_device_config_db.json
+++ b/vivintpy/zjs_device_config_db.json
@@ -420,8 +420,8 @@
     "manufacturer": "HomeSeer Technologies"
   },
   "0x000c:0x0202:0x0001": {
-    "description": "Z-Wave Indicator Light Sensor",
-    "label": "HS-FS100-L",
+    "description": "Flex Sensor",
+    "label": "HS-FS100+",
     "manufacturer": "HomeSeer Technologies"
   },
   "0x000c:0x0203:0x0001": {
@@ -5421,12 +5421,12 @@
   },
   "0x0109:0x2009:0x0901": {
     "description": "AC/DC Siren",
-    "label": "ZM1602-5",
+    "label": "ZM1602",
     "manufacturer": "Vision Security"
   },
   "0x0109:0x2009:0x0903": {
     "description": "AC/DC Siren",
-    "label": "ZM1602-5",
+    "label": "ZM1602",
     "manufacturer": "Vision Security"
   },
   "0x0109:0x2009:0x0907": {
@@ -5970,8 +5970,8 @@
     "manufacturer": "Fibargroup"
   },
   "0x010f:0x0301:0x1001": {
-    "description": "Roller Shutter",
-    "label": "FGRM222",
+    "description": "Roller Shutter 2",
+    "label": "FGR222",
     "manufacturer": "Fibargroup"
   },
   "0x010f:0x0301:0x3001": {
@@ -5980,8 +5980,8 @@
     "manufacturer": "Fibargroup"
   },
   "0x010f:0x0302:0x1000": {
-    "description": "Roller Shutter",
-    "label": "FGRM222",
+    "description": "Roller Shutter 2",
+    "label": "FGR222",
     "manufacturer": "Fibargroup"
   },
   "0x010f:0x0302:0x3000": {
@@ -7181,8 +7181,8 @@
   },
   "0x011a:0x0601:0x0901": {
     "description": "PIR Sensor",
-    "label": "ZWN-BPC",
-    "manufacturer": "Enerwave / Wenzhou MTLC Electric Appliances Co., Ltd."
+    "label": "ZWN-BPC-PLUS",
+    "manufacturer": "Wenzhou MTLC Electric Appliances Co., Ltd."
   },
   "0x011a:0x0601:0x0903": {
     "description": "Magnetic Door/Window Sensor",
@@ -9102,8 +9102,8 @@
     "manufacturer": "Popp & Co"
   },
   "0x0154:0x0004:0x0002": {
-    "description": "POPP Solar Outdoor Siren 2",
-    "label": "700854",
+    "description": "Solar Powered Outdoor Siren",
+    "label": "005107",
     "manufacturer": "Popp & Co"
   },
   "0x0154:0x0004:0x0003": {
@@ -10908,7 +10908,7 @@
   },
   "0x019b:0x0003:0x0202": {
     "description": "Floor Thermostat",
-    "label": "Z-TRM2fx",
+    "label": "Z-TRM 2",
     "manufacturer": "Heatit"
   },
   "0x019b:0x0003:0x0203": {
@@ -13840,9 +13840,9 @@
     "manufacturer": "Sunricher"
   },
   "0x0330:0x0300:0xa306": {
-    "description": "Wall Controller - 4 Button",
-    "label": "VES-ZW-WAL-008",
-    "manufacturer": "Vesternet"
+    "description": "2 Group Single Color Wall Mounted Remote",
+    "label": "ZV9001K4-DIM-G2",
+    "manufacturer": "Sunricher"
   },
   "0x0330:0x0300:0xa307": {
     "description": "Wall Controller - 2 Button",
@@ -13870,9 +13870,9 @@
     "manufacturer": "Sunricher"
   },
   "0x0330:0x0300:0xb302": {
-    "description": "4 Channel Dimmer Remote Control",
-    "label": "ZV9001K12-DIM-Z4",
-    "manufacturer": "Sunricher"
+    "description": "Remote Control - 12 Button",
+    "label": "VES-ZW-REM-010",
+    "manufacturer": "Vesternet"
   },
   "0x0330:0x0301:0xa101": {
     "description": "Wall Controller",
@@ -14500,8 +14500,8 @@
     "manufacturer": "Aeotec Ltd."
   },
   "0x0371:0x0002:0x0009": {
-    "description": "a\u00ebrQ Temperature and Humidity Sensor V2.0",
-    "label": "ZWA039",
+    "description": "a\u00ebrQ Temperature and Humidity Sensor V1.0",
+    "label": "ZWA009",
     "manufacturer": "Aeotec Ltd."
   },
   "0x0371:0x0002:0x000b": {
@@ -14645,8 +14645,8 @@
     "manufacturer": "Aeotec Ltd."
   },
   "0x0371:0x0102:0x0009": {
-    "description": "a\u00ebrQ Temperature and Humidity Sensor V2.0",
-    "label": "ZWA039",
+    "description": "a\u00ebrQ Temperature and Humidity Sensor V1.0",
+    "label": "ZWA009",
     "manufacturer": "Aeotec Ltd."
   },
   "0x0371:0x0102:0x000b": {
@@ -14770,8 +14770,8 @@
     "manufacturer": "Aeotec Ltd."
   },
   "0x0371:0x0202:0x0009": {
-    "description": "a\u00ebrQ Temperature and Humidity Sensor V2.0",
-    "label": "ZWA039",
+    "description": "a\u00ebrQ Temperature and Humidity Sensor V1.0",
+    "label": "ZWA009",
     "manufacturer": "Aeotec Ltd."
   },
   "0x0371:0x0202:0x000b": {
@@ -15904,5 +15904,5 @@
     "label": "BW8120",
     "manufacturer": "Remotec"
   },
-  "updated_at": "2026-02-23T16:28:25.861435"
+  "updated_at": "2026-03-03T13:52:10.353304"
 }


### PR DESCRIPTION
Added support for arming with an exit delay. This allows HA to send state_changed events during arming, so entities can listen and indicate it is safe to open doors, etc.

I couldn't find any information on the Vivint Sky API, and setting the arming state natively didn't work as I expected, so I implemented as local state. I couldn't think of any scenarios where this could cause a problem beyond edge cases like a user arming and then immediately disarming directly from the panel (i.e. not through this API) while the exit countdown is in progress, and even then it would behave in a predictable way. If someone figures out a way of accessing the native "arming" state, it would be slightly cleaner.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added exit-delay arming for stay and away modes with cancellation support during the delay.

* **Chores**
  * Bumped package version to a new development build.
  * Updated Z-Wave device database with clarified device names, labels, descriptions, and manufacturer entries for improved device identification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->